### PR TITLE
Refresh home cards and link AI Lab in nav

### DIFF
--- a/public/ai-lab.html
+++ b/public/ai-lab.html
@@ -19,7 +19,7 @@
 <body>
 <header class="nav"><div class="container">
   <a class="brand" href="./index.html"><span class="brand-badge">NT</span><span class="brand-text">Nicolas Tuor</span></a>
-  <nav class="nav-links"><a href="./cv.html">CV</a><a href="./portfolio.html">Portfolio</a><a href="./chatbot.html">Chatbot</a></nav>
+  <nav class="nav-links"><a href="./cv.html">CV</a><a href="./portfolio.html">Portfolio</a><a href="./ai-lab.html">AI Lab</a><a href="./chatbot.html">Chatbot</a></nav>
   <div class="nav-links"><button class="btn linkish" data-toggle-theme>🌓</button></div>
 </div></header>
 

--- a/public/chatbot-de.html
+++ b/public/chatbot-de.html
@@ -16,7 +16,7 @@
 <body>
 <header class="nav"><div class="container">
   <a class="brand" href="./index-de.html"><span class="brand-badge">NT</span><span class="brand-text">Nicolas Tuor</span></a>
-  <nav class="nav-links"><a href="./index-de.html">Start</a><a href="./cv-de.html">CV</a><a href="./portfolio-de.html">Portfolio</a></nav>
+  <nav class="nav-links"><a href="./index-de.html">Start</a><a href="./cv-de.html">CV</a><a href="./portfolio-de.html">Portfolio</a><a href="./ai-lab.html">AI Lab</a></nav>
   <div class="nav-links"><button class="btn linkish" data-toggle-theme>🌓</button><a class="btn linkish" href="./chatbot.html">FR</a><a class="btn linkish" href="./chatbot-en.html">EN</a><a class="btn linkish" href="./chatbot-de.html">DE</a></div>
 </div></header>
 

--- a/public/chatbot-en.html
+++ b/public/chatbot-en.html
@@ -8,7 +8,7 @@
 <body>
 <header class="nav"><div class="container">
   <a class="brand" href="./index-en.html"><span class="brand-badge">NT</span><span class="brand-text">Nicolas Tuor</span></a>
-  <nav class="nav-links"><a href="./index-en.html">Home</a><a href="./cv-en.html">CV</a><a href="./portfolio-en.html">Portfolio</a></nav>
+  <nav class="nav-links"><a href="./index-en.html">Home</a><a href="./cv-en.html">CV</a><a href="./portfolio-en.html">Portfolio</a><a href="./ai-lab.html">AI Lab</a></nav>
   <div class="nav-links"><button class="btn linkish" data-toggle-theme>🌓</button><a class="btn linkish" href="./chatbot.html">FR</a><a class="btn linkish" href="./chatbot-en.html">EN</a><a class="btn linkish" href="./chatbot-de.html">DE</a></div>
 </div></header>
 

--- a/public/chatbot.html
+++ b/public/chatbot.html
@@ -19,7 +19,7 @@
   <div class="container">
     <a class="brand" href="./index.html"><span class="brand-badge">NT</span><span class="brand-text">Nicolas Tuor</span></a>
     <nav class="nav-links">
-      <a href="./index.html">Accueil</a><a href="./cv.html">CV</a><a href="./portfolio.html">Portfolio</a>
+      <a href="./index.html">Accueil</a><a href="./cv.html">CV</a><a href="./portfolio.html">Portfolio</a><a href="./ai-lab.html">AI Lab</a>
     </nav>
     <div class="nav-links">
       <button class="btn linkish" data-toggle-theme>🌓</button>

--- a/public/cv-de.html
+++ b/public/cv-de.html
@@ -8,7 +8,7 @@
 <body>
 <header class="nav"><div class="container">
   <a class="brand" href="./index-de.html"><span class="brand-badge">NT</span><span class="brand-text">Nicolas Tuor</span></a>
-  <nav class="nav-links"><a href="./index-de.html">Start</a><a href="./portfolio-de.html">Portfolio</a><a href="./chatbot-de.html">Chatbot</a><button id="dlCvBtn" class="btn linkish">PDF herunterladen</button></nav>
+  <nav class="nav-links"><a href="./index-de.html">Start</a><a href="./portfolio-de.html">Portfolio</a><a href="./ai-lab.html">AI Lab</a><a href="./chatbot-de.html">Chatbot</a><button id="dlCvBtn" class="btn linkish">PDF herunterladen</button></nav>
   <div class="nav-links"><button class="btn linkish" data-toggle-theme>🌓</button><a class="btn linkish" href="./cv.html">FR</a><a class="btn linkish" href="./cv-en.html">EN</a><a class="btn linkish" href="./cv-de.html">DE</a></div>
 </div></header>
 

--- a/public/cv-en.html
+++ b/public/cv-en.html
@@ -7,7 +7,7 @@
 <body>
 <header class="nav"><div class="container">
   <a class="brand" href="./index-en.html"><span class="brand-badge">NT</span><span class="brand-text">Nicolas Tuor</span></a>
-  <nav class="nav-links"><a href="./index-en.html">Home</a><a href="./portfolio-en.html">Portfolio</a><a href="./chatbot-en.html">Chatbot</a><button id="dlCvBtn" class="btn linkish">Download PDF</button></nav>
+  <nav class="nav-links"><a href="./index-en.html">Home</a><a href="./portfolio-en.html">Portfolio</a><a href="./ai-lab.html">AI Lab</a><a href="./chatbot-en.html">Chatbot</a><button id="dlCvBtn" class="btn linkish">Download PDF</button></nav>
   <div class="nav-links"><button class="btn linkish" data-toggle-theme>🌓</button><a class="btn linkish" href="./cv.html">FR</a><a class="btn linkish" href="./cv-en.html">EN</a><a class="btn linkish" href="./cv-de.html">DE</a></div>
 </div></header>
 

--- a/public/cv.html
+++ b/public/cv.html
@@ -7,7 +7,7 @@
 <body>
 <header class="nav"><div class="container">
   <a class="brand" href="./index.html"><span class="brand-badge">NT</span><span class="brand-text">Nicolas Tuor</span></a>
-  <nav class="nav-links"><a href="./index.html">Accueil</a><a href="./portfolio.html">Portfolio</a><a href="./chatbot.html">Chatbot</a><button id="dlCvBtn" class="btn linkish">Télécharger le PDF</button></nav>
+  <nav class="nav-links"><a href="./index.html">Accueil</a><a href="./portfolio.html">Portfolio</a><a href="./ai-lab.html">AI Lab</a><a href="./chatbot.html">Chatbot</a><button id="dlCvBtn" class="btn linkish">Télécharger le PDF</button></nav>
   <div class="nav-links"><button class="btn linkish" data-toggle-theme>🌓</button><a class="btn linkish" href="./cv.html">FR</a><a class="btn linkish" href="./cv-en.html">EN</a><a class="btn linkish" href="./cv-de.html">DE</a></div>
 </div></header>
 
@@ -29,6 +29,6 @@
 <script src="./cv-data.js"></script>
 <script src="./cv.js"></script>
 <script src="./site.js" defer></script>
-<script>(function(){const k="theme",h=document.documentElement,s=localStorage.getItem(k);if(s)h.setAttribute("data-theme",s);function set(v){h.setAttribute("data-theme",v);localStorage.setItem(k,v);}document.addEventListener("click",e=>{const t=e.target.closest("[data-toggle-theme]");if(!t)return;set(h.getAttribute("data-theme")==="light"?"dark":"light");});if(!s)set("dark");})();</script>
+<script>(function(){const K="theme",H=document.documentElement,S=localStorage.getItem(K);if(S)H.setAttribute("data-theme",S);function set(t){H.setAttribute("data-theme",t);localStorage.setItem(K,t);}document.addEventListener("click",e=>{const t=e.target.closest("[data-toggle-theme]");if(!t)return;set(H.getAttribute("data-theme")==="light"?"dark":"light");});if(!S)set("dark");})();</script>
 </body>
 </html>

--- a/public/index-de.html
+++ b/public/index-de.html
@@ -10,7 +10,7 @@
   <div class="container">
     <a class="brand" href="./index-de.html"><span class="brand-badge">NT</span><span class="brand-text">Nicolas Tuor</span></a>
     <nav class="nav-links">
-      <a href="./cv-de.html">CV</a><a href="./portfolio-de.html">Portfolio</a><a href="./chatbot-de.html">Chatbot</a>
+      <a href="./cv-de.html">CV</a><a href="./portfolio-de.html">Portfolio</a><a href="./ai-lab.html">AI Lab</a><a href="./chatbot-de.html">Chatbot</a>
       <button id="dlCvBtn" class="btn linkish">PDF herunterladen</button>
     </nav>
     <div class="nav-links">
@@ -24,9 +24,34 @@
   <h1 class="title">Informatikdidaktik & <span class="stroke">verantwortungsvolle KI</span></h1>
   <p class="lead">Klare Lernsequenzen, Erfolgskriterien und ein maßvoller KI-Einsatz — echte Fortschritte ohne die Ansprüche zu senken.</p>
   <div class="buttons"><a class="btn primary" href="./cv-de.html">Zum CV</a><a class="btn" href="./portfolio-de.html">Projekte</a><a class="btn ghost" href="./chatbot-de.html">💬 „Warum mich einstellen?“</a></div>
+  <div class="cards">
+    <div class="card" tabindex="0">
+      <div class="face front">🧠</div>
+      <div class="face back"><strong>Kritisches Denken</strong><br>Prüfen, vergleichen, Kriterien offenlegen.</div>
+    </div>
+    <div class="card" tabindex="0">
+      <div class="face front">🧭</div>
+      <div class="face back"><strong>Gezielte Begleitung</strong><br>Klar formulierte Ziele, gestufte Hilfen, häufiges Feedback.</div>
+    </div>
+    <div class="card" tabindex="0">
+      <div class="face front">🤖</div>
+      <div class="face back"><strong>Verantwortungsvolle KI</strong><br>Nutzen messen, Ansprüche halten, ethisch bleiben.</div>
+    </div>
+    <div class="card" tabindex="0">
+      <div class="face back"><strong>Hobbys</strong><br>Digitales Tüfteln, Tech-Scouting, Natur & Sport.</div>
+      <div class="face front">🌿</div>
+    </div>
+  </div>
+  <script>
+    document.querySelectorAll('.card').forEach(c=>{
+      const flip=()=>c.classList.toggle('flipped');
+      c.addEventListener('click', flip);
+      c.addEventListener('keydown', e=>{ if(e.key==='Enter'||e.key===' '){ e.preventDefault(); flip(); }});
+    });
+  </script>
 </main>
 
 <script src="./site.js" defer></script>
-<script>(function(){const k="theme",h=document.documentElement,s=localStorage.getItem(k);if(s)h.setAttribute("data-theme",s);function set(v){h.setAttribute("data-theme",v);localStorage.setItem(k,v);}document.addEventListener("click",e=>{const t=e.target.closest("[data-toggle-theme]");if(!t)return;set(h.getAttribute("data-theme")==="light"?"dark":"light");});if(!s)set("dark");})();</script>
+<script>(function(){const K="theme",H=document.documentElement,S=localStorage.getItem(K);if(S)H.setAttribute("data-theme",S);function set(t){H.setAttribute("data-theme",t);localStorage.setItem(K,t);}document.addEventListener("click",e=>{const t=e.target.closest("[data-toggle-theme]");if(!t)return;set(H.getAttribute("data-theme")==="light"?"dark":"light");});if(!S)set("dark");})();</script>
 </body>
 </html>

--- a/public/index-en.html
+++ b/public/index-en.html
@@ -8,7 +8,7 @@
 <body>
 <header class="nav"><div class="container">
   <a class="brand" href="./index-en.html"><span class="brand-badge">NT</span><span class="brand-text">Nicolas Tuor</span></a>
-  <nav class="nav-links"><a href="./cv-en.html">CV</a><a href="./portfolio-en.html">Portfolio</a><a href="./chatbot-en.html">AI Chatbot</a><button id="dlCvBtn" class="btn linkish">Download CV</button></nav>
+  <nav class="nav-links"><a href="./cv-en.html">CV</a><a href="./portfolio-en.html">Portfolio</a><a href="./ai-lab.html">AI Lab</a><a href="./chatbot-en.html">AI Chatbot</a><button id="dlCvBtn" class="btn linkish">Download CV</button></nav>
   <div class="nav-links"><button class="btn linkish" data-toggle-theme>🌓</button><a class="btn linkish" href="./index.html">FR</a><a class="btn linkish" href="./index-en.html">EN</a><a class="btn linkish" href="./index-de.html">DE</a></div>
 </div></header>
 
@@ -21,11 +21,30 @@
       <ul class="kpis"><li>🧠 Critical thinking</li><li>🧭 Didactics</li><li>📚 Primary</li><li>🤖 AI</li></ul>
     </div>
     <div class="cards">
-      <div class="card" tabindex="0"><div class="face front">🧭</div><div class="face back">Scaffolding: clear goals, support, frequent feedback.</div></div>
-      <div class="card" tabindex="0"><div class="face front">✅</div><div class="face back">Assess to learn: shared criteria, rubrics, micro-reviews.</div></div>
-      <div class="card" tabindex="0"><div class="face front">🤖</div><div class="face back">Responsible AI: measured gains, keep requirements.</div></div>
-      <div class="card" tabindex="0"><div class="face front">🗣️</div><div class="face back">Clear communication: narrated examples, reformulation.</div></div>
+      <div class="card" tabindex="0">
+        <div class="face front">🧠</div>
+        <div class="face back"><strong>Critical thinking</strong><br>Verify, compare, make success criteria explicit.</div>
+      </div>
+      <div class="card" tabindex="0">
+        <div class="face front">🧭</div>
+        <div class="face back"><strong>Scaffolding</strong><br>Clear goals, layered supports, frequent feedback.</div>
+      </div>
+      <div class="card" tabindex="0">
+        <div class="face front">🤖</div>
+        <div class="face back"><strong>Responsible AI</strong><br>Measure gains, keep expectations high, stay ethical.</div>
+      </div>
+      <div class="card" tabindex="0">
+        <div class="face back"><strong>Hobbies</strong><br>Creative coding, tech watch, outdoors & sport.</div>
+        <div class="face front">🌿</div>
+      </div>
     </div>
+    <script>
+      document.querySelectorAll('.card').forEach(c=>{
+        const flip=()=>c.classList.toggle('flipped');
+        c.addEventListener('click', flip);
+        c.addEventListener('keydown', e=>{ if(e.key==='Enter'||e.key===' '){ e.preventDefault(); flip(); }});
+      });
+    </script>
   </div></section>
 
   <section class="section"><div class="container demo">
@@ -54,8 +73,6 @@
 <footer class="footer"><div class="container foot"><div><strong>NT</strong> — Nicolas Tuor · Fribourg (CH)</div><div class="nav-links"><a href="./cv-en.html">CV</a><a href="./portfolio-en.html">Portfolio</a><a href="./chatbot-en.html">Chatbot</a></div></div></footer>
 
 <script>
-// flip
-document.querySelectorAll('.card').forEach(c=>{const f=()=>c.classList.toggle('flipped');c.addEventListener('click',f);c.addEventListener('keydown',e=>{if(e.key==='Enter'||e.key===' '){e.preventDefault();f();}});});
 // IA quiz
 const qText=document.getElementById('qText'),choices=document.getElementById('choices'),explain=document.getElementById('explain'),score=document.getElementById('score');
 let i=0,right=0,Qs=[];

--- a/public/index.html
+++ b/public/index.html
@@ -11,7 +11,7 @@
   <div class="container">
     <a class="brand" href="./index.html"><span class="brand-badge">NT</span><span class="brand-text">Nicolas Tuor</span></a>
     <nav class="nav-links">
-      <a href="./cv.html">CV</a><a href="./portfolio.html">Portfolio</a><a href="./chatbot.html">Chatbot IA</a>
+      <a href="./cv.html">CV</a><a href="./portfolio.html">Portfolio</a><a href="./ai-lab.html">AI Lab</a><a href="./chatbot.html">Chatbot IA</a>
       <button id="dlCvBtn" class="btn linkish">Télécharger le CV</button>
     </nav>
     <div class="nav-links">
@@ -35,13 +35,31 @@
         </div>
         <ul class="kpis"><li>🧠 Pensée critique</li><li>🧭 Didactique</li><li>📚 Primaire</li><li>🤖 IA</li></ul>
       </div>
-      <!-- Cartes : icône devant, texte au dos -->
       <div class="cards">
-        <div class="card" tabindex="0"><div class="face front" aria-hidden="true">🧭</div><div class="face back">Guidage progressif : objectifs clairs, étayage, feedback.</div></div>
-        <div class="card" tabindex="0"><div class="face front" aria-hidden="true">✅</div><div class="face back">Évaluer pour apprendre : critères partagés, rubriques, micro-révisions.</div></div>
-        <div class="card" tabindex="0"><div class="face front" aria-hidden="true">🤖</div><div class="face back">IA responsable : gains mesurés, vigilance, respect des attendus.</div></div>
-        <div class="card" tabindex="0"><div class="face front" aria-hidden="true">🗣️</div><div class="face back">Communication claire : consignes narrées, exemples, reformulation.</div></div>
+        <div class="card" tabindex="0">
+          <div class="face front">🧠</div>
+          <div class="face back"><strong>Pensée critique</strong><br>Vérifier, comparer, expliciter les critères.</div>
+        </div>
+        <div class="card" tabindex="0">
+          <div class="face front">🧭</div>
+          <div class="face back"><strong>Guidage progressif</strong><br>Objectifs clairs, supports étagés, retours fréquents.</div>
+        </div>
+        <div class="card" tabindex="0">
+          <div class="face front">🤖</div>
+          <div class="face back"><strong>IA responsable</strong><br>Gains mesurés, exigences maintenues, éthique.</div>
+        </div>
+        <div class="card" tabindex="0">
+          <div class="face back"><strong>Hobbies</strong><br>bricolage numérique, veille techno, nature/sport.</div>
+          <div class="face front">🌿</div>
+        </div>
       </div>
+      <script>
+        document.querySelectorAll('.card').forEach(c=>{
+          const flip=()=>c.classList.toggle('flipped');
+          c.addEventListener('click', flip);
+          c.addEventListener('keydown', e=>{ if(e.key==='Enter'||e.key===' '){ e.preventDefault(); flip(); }});
+        });
+      </script>
     </div>
   </section>
 
@@ -89,13 +107,6 @@
 
 <!-- flips + jeu + mode nuit + protections -->
 <script>
-  // flip cards
-  document.querySelectorAll('.card').forEach(c => {
-    const flip = () => c.classList.toggle('flipped');
-    c.addEventListener('click', flip);
-    c.addEventListener('keydown', e => (e.key==='Enter'||e.key===' ') && (e.preventDefault(), flip()));
-  });
-
   // mini-jeu : Info ou Intox (3 questions)
   const QUESTIONS = [
     { q: "Un article sans date ni source fiable est-il crédible ?", choices: ["Probablement oui", "Plutôt non"], ok: 1, why: "Absence de date/source = signal faible de fiabilité." },
@@ -120,9 +131,6 @@
   draw();
 </script>
 <script src="./site.js" defer></script>
-<script>
-  // mode nuit persisté
-  (function(){const k="theme",h=document.documentElement,s=localStorage.getItem(k);if(s)h.setAttribute("data-theme",s);function set(v){h.setAttribute("data-theme",v);localStorage.setItem(k,v);}document.addEventListener("click",e=>{const t=e.target.closest("[data-toggle-theme]");if(!t)return;set(h.getAttribute("data-theme")==="light"?"dark":"light");});if(!s)set("dark");})();
-</script>
+<script>(function(){const K="theme",H=document.documentElement,S=localStorage.getItem(K);if(S)H.setAttribute("data-theme",S);function set(t){H.setAttribute("data-theme",t);localStorage.setItem(K,t);}document.addEventListener("click",e=>{const t=e.target.closest("[data-toggle-theme]");if(!t)return;set(H.getAttribute("data-theme")==="light"?"dark":"light");});if(!S)set("dark");})();</script>
 </body>
 </html>

--- a/public/portfolio-de.html
+++ b/public/portfolio-de.html
@@ -8,7 +8,7 @@
 <body>
 <header class="nav"><div class="container">
   <a class="brand" href="./index-de.html"><span class="brand-badge">NT</span><span class="brand-text">Nicolas Tuor</span></a>
-  <nav class="nav-links"><a href="./index-de.html">Start</a><a href="./cv-de.html">CV</a><a href="./chatbot-de.html">Chatbot</a></nav>
+  <nav class="nav-links"><a href="./index-de.html">Start</a><a href="./cv-de.html">CV</a><a href="./ai-lab.html">AI Lab</a><a href="./chatbot-de.html">Chatbot</a></nav>
   <div class="nav-links"><button class="btn linkish" data-toggle-theme>🌓</button><a class="btn linkish" href="./portfolio.html">FR</a><a class="btn linkish" href="./portfolio-en.html">EN</a><a class="btn linkish" href="./portfolio-de.html">DE</a></div>
 </div></header>
 

--- a/public/portfolio-en.html
+++ b/public/portfolio-en.html
@@ -7,7 +7,7 @@
 <body>
 <header class="nav"><div class="container">
   <a class="brand" href="./index-en.html"><span class="brand-badge">NT</span><span class="brand-text">Nicolas Tuor</span></a>
-  <nav class="nav-links"><a href="./index-en.html">Home</a><a href="./cv-en.html">CV</a><a href="./chatbot-en.html">Chatbot</a></nav>
+  <nav class="nav-links"><a href="./index-en.html">Home</a><a href="./cv-en.html">CV</a><a href="./ai-lab.html">AI Lab</a><a href="./chatbot-en.html">Chatbot</a></nav>
   <div class="nav-links"><button class="btn linkish" data-toggle-theme>🌓</button><a class="btn linkish" href="./portfolio.html">FR</a><a class="btn linkish" href="./portfolio-en.html">EN</a><a class="btn linkish" href="./portfolio-de.html">DE</a></div>
 </div></header>
 

--- a/public/portfolio.html
+++ b/public/portfolio.html
@@ -9,7 +9,7 @@
 <header class="nav">
   <div class="container">
     <a class="brand" href="./index.html"><span class="brand-badge">NT</span><span class="brand-text">Nicolas Tuor</span></a>
-    <nav class="nav-links"><a href="./index.html">Accueil</a><a href="./cv.html">CV</a><a href="./chatbot.html">Chatbot</a><button id="dlCvBtn" class="btn linkish">Télécharger le CV</button></nav>
+    <nav class="nav-links"><a href="./index.html">Accueil</a><a href="./cv.html">CV</a><a href="./ai-lab.html">AI Lab</a><a href="./chatbot.html">Chatbot</a><button id="dlCvBtn" class="btn linkish">Télécharger le CV</button></nav>
     <div class="nav-links"><button class="btn linkish" data-toggle-theme>🌓</button><a class="btn linkish" href="./portfolio.html">FR</a><a class="btn linkish" href="./portfolio-en.html">EN</a><a class="btn linkish" href="./portfolio-de.html">DE</a></div>
   </div>
 </header>
@@ -30,6 +30,6 @@
 <script src="./portfolio-data.js"></script>
 <script src="./portfolio.js"></script>
 <script src="./site.js" defer></script>
-<script>(function(){const k="theme",h=document.documentElement,s=localStorage.getItem(k);if(s)h.setAttribute("data-theme",s);function set(v){h.setAttribute("data-theme",v);localStorage.setItem(k,v);}document.addEventListener("click",e=>{const t=e.target.closest("[data-toggle-theme]");if(!t)return;set(h.getAttribute("data-theme")==="light"?"dark":"light");});if(!s)set("dark");})();</script>
+<script>(function(){const K="theme",H=document.documentElement,S=localStorage.getItem(K);if(S)H.setAttribute("data-theme",S);function set(t){H.setAttribute("data-theme",t);localStorage.setItem(K,t);}document.addEventListener("click",e=>{const t=e.target.closest("[data-toggle-theme]");if(!t)return;set(H.getAttribute("data-theme")==="light"?"dark":"light");});if(!S)set("dark");})();</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace the 4-card grid on the FR/EN/DE landing pages with the new copy and flip handler
- add the AI Lab link to the shared navigation and standardize the stored theme toggle script where needed

## Testing
- not run (static HTML changes)


------
https://chatgpt.com/codex/tasks/task_e_68c96114f9088329bab8c31f8c58ce7b