### PR TITLE
Add site-wide SVG favicon and update rewrites

### DIFF
--- a/public/ai-lab.html
+++ b/public/ai-lab.html
@@ -2,6 +2,7 @@
 <html lang="fr" data-theme="dark">
 <head>
   <meta charset="utf-8" />
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Idées IA en éducation — Nicolas Tuor</title>
   <link rel="stylesheet" href="./style.css" />

--- a/public/chatbot-de.html
+++ b/public/chatbot-de.html
@@ -1,7 +1,9 @@
 <!DOCTYPE html>
 <html lang="de" data-theme="dark">
 <head>
-  <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta charset="utf-8">
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>KI-Chatbot — Nicolas Tuor</title>
   <link rel="stylesheet" href="./style.css">
   <style>

--- a/public/chatbot-en.html
+++ b/public/chatbot-en.html
@@ -1,7 +1,9 @@
 <!DOCTYPE html>
 <html lang="en" data-theme="dark">
 <head>
-  <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta charset="utf-8">
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>AI Chatbot — Nicolas Tuor</title><link rel="stylesheet" href="./style.css">
   <style>.chat{max-width:820px;margin:0 auto}.chat-box{background:var(--panel);border:1px solid color-mix(in oklab,var(--ink),transparent 85%);border-radius:16px;padding:14px;box-shadow:var(--shadow);min-height:260px}.msg{background:var(--bg-soft);border:1px solid color-mix(in oklab,var(--ink),transparent 85%);padding:10px 12px;border-radius:12px;margin:10px 0}.me{border-color:color-mix(in oklab,var(--brand),transparent 70%)}.row{display:flex;gap:10px;margin-top:10px}.row input{flex:1;padding:10px;border-radius:10px;border:1px solid color-mix(in oklab,var(--ink),transparent 80%);background:var(--bg-soft);color:var(--ink)}</style>
 </head>

--- a/public/chatbot.html
+++ b/public/chatbot.html
@@ -2,6 +2,7 @@
 <html lang="fr" data-theme="dark">
 <head>
   <meta charset="utf-8">
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Chatbot IA — Nicolas Tuor</title>
   <link rel="stylesheet" href="./style.css">

--- a/public/cv-de.html
+++ b/public/cv-de.html
@@ -1,7 +1,9 @@
 <!DOCTYPE html>
 <html lang="de" data-theme="dark">
 <head>
-  <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta charset="utf-8">
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>CV — Nicolas Tuor</title>
   <link rel="stylesheet" href="./style.css">
 </head>

--- a/public/cv-en.html
+++ b/public/cv-en.html
@@ -1,8 +1,11 @@
 <!DOCTYPE html>
 <html lang="en" data-theme="dark">
 <head>
-  <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>CV — Nicolas Tuor</title><link rel="stylesheet" href="./style.css">
+  <meta charset="utf-8">
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>CV — Nicolas Tuor</title>
+  <link rel="stylesheet" href="./style.css">
 </head>
 <body>
 <header class="nav"><div class="container">

--- a/public/cv.html
+++ b/public/cv.html
@@ -2,10 +2,10 @@
 <html lang="fr" data-theme="dark">
 <head>
   <meta charset="utf-8">
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>CV — Nicolas Tuor</title>
   <link rel="stylesheet" href="./style.css">
-  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>📄</text></svg>">
 </head>
 <body>
 <header class="nav">

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Brain icon">
+  <defs>
+    <linearGradient id="brainGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#f9e3ff" />
+      <stop offset="100%" stop-color="#d7b4ff" />
+    </linearGradient>
+  </defs>
+  <path fill="url(#brainGradient)" d="M22 8c-6.6 0-12 5.4-12 12v3.5C5.1 26.6 2 31.6 2 37.3 2 47.4 10.6 56 20.7 56h1.1C23.3 60 27.3 62.8 32 62.8s8.7-2.8 10.2-6.8h1.1C53.4 56 62 47.4 62 37.3c0-8.2-5.3-15.3-12.8-17.7-.6-7.7-7-13.6-14.8-13.6-3.6 0-6.9 1.2-9.5 3.2C24.1 8.3 23.1 8 22 8Z" />
+  <path fill="none" stroke="#8d5de8" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" d="M20 18c-4.5 2.2-7.5 7-7.5 12.3 0 7.4 6 13.4 13.4 13.4h2.1M44 18c4.5 2.2 7.5 7 7.5 12.3 0 7.4-6 13.4-13.4 13.4H36M32 14v34M24 12c-2.8-4.2-9.5-2-9.5 3.6M40 12c2.8-4.2 9.5-2 9.5 3.6" />
+</svg>

--- a/public/index-de.html
+++ b/public/index-de.html
@@ -2,6 +2,7 @@
 <html lang="de" data-theme="dark">
 <head>
   <meta charset="utf-8" />
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Nicolas Tuor — Informatikdidaktik & verantwortungsvolle KI</title>
   <link rel="stylesheet" href="./style.css" />

--- a/public/index-en.html
+++ b/public/index-en.html
@@ -2,6 +2,7 @@
 <html lang="en" data-theme="dark">
 <head>
   <meta charset="utf-8" />
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Nicolas Tuor — CS Didactics & Responsible AI</title>
   <link rel="stylesheet" href="./style.css" />

--- a/public/index.html
+++ b/public/index.html
@@ -2,6 +2,7 @@
 <html lang="fr" data-theme="dark">
 <head>
   <meta charset="utf-8" />
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Nicolas Tuor — Didactique de l’informatique & IA</title>
   <link rel="stylesheet" href="./style.css" />

--- a/public/portfolio-de.html
+++ b/public/portfolio-de.html
@@ -1,7 +1,9 @@
 <!DOCTYPE html>
 <html lang="de" data-theme="dark">
 <head>
-  <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta charset="utf-8">
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Portfolio — Nicolas Tuor</title>
   <link rel="stylesheet" href="./style.css">
 </head>

--- a/public/portfolio-en.html
+++ b/public/portfolio-en.html
@@ -1,7 +1,9 @@
 <!DOCTYPE html>
 <html lang="en" data-theme="dark">
 <head>
-  <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta charset="utf-8">
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Portfolio — Nicolas Tuor</title><link rel="stylesheet" href="./style.css">
 </head>
 <body>

--- a/public/portfolio.html
+++ b/public/portfolio.html
@@ -1,7 +1,9 @@
 <!DOCTYPE html>
 <html lang="fr" data-theme="dark">
 <head>
-  <meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta charset="UTF-8">
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Portfolio — Nicolas Tuor</title>
   <link rel="stylesheet" href="./style.css">
 </head>

--- a/vercel.json
+++ b/vercel.json
@@ -1,1 +1,6 @@
-{ "cleanUrls": true }
+{
+  "cleanUrls": true,
+  "rewrites": [
+    { "source": "/favicon.ico", "destination": "/favicon.svg" }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a shared brain-themed SVG favicon under `public/favicon.svg`
- link the favicon from each static HTML page and remove the old data-URL icon
- configure Vercel to rewrite `/favicon.ico` to `/favicon.svg`

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68c9777d024c83298197d3f9459feb70