### PR TITLE
Align navigation labels and formal tone across locales

### DIFF
--- a/public/chatbot-de.html
+++ b/public/chatbot-de.html
@@ -18,15 +18,15 @@
 <body>
 <header class="nav"><div class="container">
   <a class="brand" href="./index-de.html"><span class="brand-badge">NT</span><span class="brand-text">Nicolas Tuor</span></a>
-  <nav class="nav-links"><a href="./index-de.html">Start</a><a href="./cv-de.html">CV</a><a href="./portfolio-de.html">Portfolio</a><a href="./ai-lab.html">AI Lab</a></nav>
+  <nav class="nav-links"><a href="./index-de.html">Start</a><a href="./cv-de.html">CV</a><a href="./portfolio-de.html">Portfolio</a><a href="./ai-lab.html">KI-Ideen im Unterricht</a></nav>
   <div class="nav-links"><button class="btn linkish" data-toggle-theme>🌓</button><a class="btn linkish" href="./chatbot.html">FR</a><a class="btn linkish" href="./chatbot-en.html">EN</a><a class="btn linkish" href="./chatbot-de.html">DE</a></div>
 </div></header>
 
 <main class="section container chat">
   <h1 class="title">🤖 KI-Chatbot</h1>
-  <p class="lead">Frag, warum ich passe (Erfahrung, Pädagogik, KI).</p>
+  <p class="lead">Fragen Sie, warum ich gut passe (Erfahrung, Pädagogik, KI).</p>
   <div id="chat" class="chat-box"></div>
-  <div class="row"><input id="q" placeholder="z.B. Setzt er KI verantwortungsvoll ein?"><button id="send" class="btn primary">Senden</button></div>
+  <div class="row"><input id="q" placeholder="„z. B. Setzen Sie KI verantwortungsvoll im Unterricht ein?“"><button id="send" class="btn primary">Senden</button></div>
 </main>
 
 <script>

--- a/public/chatbot-en.html
+++ b/public/chatbot-en.html
@@ -10,7 +10,7 @@
 <body>
 <header class="nav"><div class="container">
   <a class="brand" href="./index-en.html"><span class="brand-badge">NT</span><span class="brand-text">Nicolas Tuor</span></a>
-  <nav class="nav-links"><a href="./index-en.html">Home</a><a href="./cv-en.html">CV</a><a href="./portfolio-en.html">Portfolio</a><a href="./ai-lab.html">AI Lab</a></nav>
+  <nav class="nav-links"><a href="./index-en.html">Home</a><a href="./cv-en.html">CV</a><a href="./portfolio-en.html">Portfolio</a><a href="./ai-lab.html">Ideas for AI in Education</a></nav>
   <div class="nav-links"><button class="btn linkish" data-toggle-theme>🌓</button><a class="btn linkish" href="./chatbot.html">FR</a><a class="btn linkish" href="./chatbot-en.html">EN</a><a class="btn linkish" href="./chatbot-de.html">DE</a></div>
 </div></header>
 
@@ -18,7 +18,7 @@
   <h1 class="title">🤖 AI Chatbot</h1>
   <p class="lead">Ask why I’m a good fit (experience, pedagogy, AI).</p>
   <div id="chat" class="chat-box"></div>
-  <div class="row"><input id="q" placeholder="e.g., Does he use AI responsibly in class?"><button id="send" class="btn primary">Send</button></div>
+  <div class="row"><input id="q" placeholder="e.g., Do you use AI responsibly in class?"><button id="send" class="btn primary">Send</button></div>
 </main>
 
 <script>

--- a/public/chatbot.html
+++ b/public/chatbot.html
@@ -20,7 +20,7 @@
   <div class="container">
     <a class="brand" href="./index.html"><span class="brand-badge">NT</span><span class="brand-text">Nicolas Tuor</span></a>
     <nav class="nav-links">
-      <a href="./index.html">Accueil</a><a href="./cv.html">CV</a><a href="./portfolio.html">Portfolio</a><a href="./ai-lab.html">AI Lab</a>
+      <a href="./index.html">Accueil</a><a href="./cv.html">CV</a><a href="./portfolio.html">Portfolio</a><a href="./ai-lab.html">Idées IA en éducation</a>
     </nav>
     <div class="nav-links">
       <button class="btn linkish" data-toggle-theme>🌓</button>
@@ -31,12 +31,12 @@
 
 <main class="section container chat">
   <h1 class="title">🤖 Chatbot IA</h1>
-  <p class="lead">Pose une question pour savoir pourquoi m’embaucher (expérience, compétences, pédagogie, IA).</p>
+  <p class="lead">Posez une question pour savoir pourquoi m’embaucher (expérience, compétences, pédagogie, IA).</p>
 
   <div id="chat" class="chat-box"></div>
 
   <div class="row">
-    <input id="q" type="text" placeholder="ex. Est-ce qu’il maîtrise l’IA à l’école ?" />
+    <input id="q" type="text" placeholder="Par ex. Utilisez-vous l’IA de manière responsable en classe ?" />
     <button id="send" class="btn primary">Envoyer</button>
   </div>
 </main>

--- a/public/cv-de.html
+++ b/public/cv-de.html
@@ -10,7 +10,7 @@
 <body>
 <header class="nav"><div class="container">
   <a class="brand" href="./index-de.html"><span class="brand-badge">NT</span><span class="brand-text">Nicolas Tuor</span></a>
-  <nav class="nav-links"><a href="./index-de.html">Start</a><a href="./portfolio-de.html">Portfolio</a><a href="./ai-lab.html">AI Lab</a><a href="./chatbot-de.html">Chatbot</a><button id="dlCvBtn" class="btn linkish">PDF herunterladen</button></nav>
+  <nav class="nav-links"><a href="./index-de.html">Start</a><a href="./portfolio-de.html">Portfolio</a><a href="./ai-lab.html">KI-Ideen im Unterricht</a><a href="./chatbot-de.html">Chatbot</a><button id="dlCvBtn" class="btn linkish">PDF herunterladen</button></nav>
   <div class="nav-links"><button class="btn linkish" data-toggle-theme>🌓</button><a class="btn linkish" href="./cv.html">FR</a><a class="btn linkish" href="./cv-en.html">EN</a><a class="btn linkish" href="./cv-de.html">DE</a></div>
 </div></header>
 
@@ -19,7 +19,7 @@
   <div class="cv-toolbar">
     <label>Ansicht:
       <select id="viewMode" class="select">
-        <option value="pdf">Eingebettetes PDF</option>
+        <option value="pdf">Geschütztes PDF</option>
         <option value="constellation">Kompetenz-Konstellation (interaktiv)</option>
         <option value="story">Unterrichts-Storyboard (interaktiv)</option>
       </select>

--- a/public/cv-en.html
+++ b/public/cv-en.html
@@ -10,7 +10,7 @@
 <body>
 <header class="nav"><div class="container">
   <a class="brand" href="./index-en.html"><span class="brand-badge">NT</span><span class="brand-text">Nicolas Tuor</span></a>
-  <nav class="nav-links"><a href="./index-en.html">Home</a><a href="./portfolio-en.html">Portfolio</a><a href="./ai-lab.html">AI Lab</a><a href="./chatbot-en.html">Chatbot</a><button id="dlCvBtn" class="btn linkish">Download PDF</button></nav>
+  <nav class="nav-links"><a href="./index-en.html">Home</a><a href="./portfolio-en.html">Portfolio</a><a href="./ai-lab.html">Ideas for AI in Education</a><a href="./chatbot-en.html">Chatbot</a><button id="dlCvBtn" class="btn linkish">Download PDF</button></nav>
   <div class="nav-links"><button class="btn linkish" data-toggle-theme>🌓</button><a class="btn linkish" href="./cv.html">FR</a><a class="btn linkish" href="./cv-en.html">EN</a><a class="btn linkish" href="./cv-de.html">DE</a></div>
 </div></header>
 
@@ -19,7 +19,7 @@
   <div class="cv-toolbar">
     <label>Display:
       <select id="viewMode" class="select">
-        <option value="pdf">Integrated PDF</option>
+        <option value="pdf">Protected PDF</option>
         <option value="constellation">Skills constellation (interactive)</option>
         <option value="story">Lesson storyboard (interactive)</option>
       </select>

--- a/public/index-de.html
+++ b/public/index-de.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
-  <title>Nicolas Tuor — Informatikdidaktik & verantwortungsvolle KI</title>
+  <title>Nicolas Tuor — Informatikdidaktik & verantwortungsvolle KI im Unterricht</title>
   <link rel="stylesheet" href="./style.css" />
 </head>
 <body>
@@ -34,11 +34,11 @@
   <section class="hero">
     <div class="container hero-grid">
       <div>
-        <h1 class="xxl">Informatikdidaktik & <span class="accent">verantwortungsvolle KI</span></h1>
+        <h1 class="xxl">Informatikdidaktik & <span class="accent">verantwortungsvolle KI im Unterricht</span></h1>
         <p class="lead">Explizites Lernen, Erfolgskriterien und maßvoller KI-Einsatz — echte Fortschritte ohne die Ansprüche zu senken.</p>
         <div class="row gap">
           <a class="btn primary" href="./cv-de.html">Zum CV</a>
-          <a class="btn ghost" href="./portfolio-de.html">Projekte</a>
+          <a class="btn ghost" href="./portfolio-de.html">Beispiele</a>
           <a class="btn ghost" href="./chatbot-de.html">💬 „Warum mich einstellen?“</a>
         </div>
         <ul class="kpis">

--- a/public/index-en.html
+++ b/public/index-en.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
-  <title>Nicolas Tuor — CS Didactics & Responsible AI</title>
+  <title>Nicolas Tuor — Computer Science Didactics & Education with AI</title>
   <link rel="stylesheet" href="./style.css" />
 </head>
 <body>
@@ -17,9 +17,9 @@
     <nav class="nav-links">
       <a href="./cv-en.html">CV</a>
       <a href="./portfolio-en.html">Portfolio</a>
-      <a href="./ai-lab.html">AI Ideas for Education</a>
+      <a href="./ai-lab.html">Ideas for AI in Education</a>
       <a href="./chatbot-en.html">Chatbot</a>
-      <button id="dlCvBtn" class="btn linkish">Download CV</button>
+      <button id="dlCvBtn" class="btn linkish">Download PDF</button>
     </nav>
     <nav class="nav-links">
       <button class="btn linkish" data-toggle-theme title="Toggle theme">🌓</button>
@@ -34,12 +34,12 @@
   <section class="hero">
     <div class="container hero-grid">
       <div>
-        <h1 class="xxl">Computer-Science Didactics & <span class="accent">Responsible AI</span></h1>
+        <h1 class="xxl">Computer Science Didactics & <span class="accent">Education with AI</span></h1>
         <p class="lead">Explicit teaching, success criteria and thoughtful AI — concrete gains without lowering expectations.</p>
         <div class="row gap">
           <a class="btn primary" href="./cv-en.html">View CV</a>
           <a class="btn ghost" href="./portfolio-en.html">Examples</a>
-          <a class="btn ghost" href="./chatbot-en.html">💬 “Why hire me?” bot</a>
+          <a class="btn ghost" href="./chatbot-en.html">💬 “Why hire me?”</a>
         </div>
         <ul class="kpis">
           <li>🧠 Critical thinking</li>
@@ -87,7 +87,7 @@
           <textarea id="fProof" rows="2" placeholder="Evidence found, counter-examples…"></textarea>
         </div>
 
-        <button class="btn primary" data-busy>Get feedback</button>
+        <button class="btn primary" data-busy>Request feedback</button>
       </form>
 
       <pre id="factOut" class="code" style="margin-top:12px;white-space:pre-wrap"></pre>

--- a/public/index.html
+++ b/public/index.html
@@ -40,7 +40,7 @@
     <div class="row gap">
       <a class="btn primary" href="./cv">Voir le CV</a>
       <a class="btn linkish" href="./portfolio">Exemples</a>
-      <a class="btn linkish" href="./chatbot">💬 “Pourquoi m’embaucher ?”</a>
+      <a class="btn linkish" href="./chatbot">💬 « Pourquoi vous devriez m’embaucher ? »</a>
     </div>
   </section>
 
@@ -48,14 +48,14 @@
 
   <!-- RUCHE PÉDAGOGIQUE (Beehive Simulator) -->
   <section class="container section">
-    <h2 class="h3">Ruche pédagogique — <span class="muted">paramètre une ruche équilibrée pour “débloquer” un aperçu de mon CV</span></h2>
+    <h2 class="h3">Ruche pédagogique — <span class="muted">paramétrez une ruche équilibrée pour “débloquer” un aperçu de mon CV</span></h2>
 
     <div class="grid" style="grid-template-columns: 380px 1fr">
       <!-- Panneau de contrôle -->
       <div class="card pad stack">
         <p class="muted" style="margin-top:0">
           <strong>But :</strong> stabiliser la ruche <em>(santé ≥ 80 pendant 15 cycles)</em> en ajustant les paramètres.
-          Tu verras alors un résumé de mon CV.
+          Vous verrez alors un résumé de mon CV.
         </p>
 
         <label>Fleurs à proximité (nectar)

--- a/public/portfolio-de.html
+++ b/public/portfolio-de.html
@@ -10,7 +10,7 @@
 <body>
 <header class="nav"><div class="container">
   <a class="brand" href="./index-de.html"><span class="brand-badge">NT</span><span class="brand-text">Nicolas Tuor</span></a>
-  <nav class="nav-links"><a href="./index-de.html">Start</a><a href="./cv-de.html">CV</a><a href="./ai-lab.html">AI Lab</a><a href="./chatbot-de.html">Chatbot</a></nav>
+  <nav class="nav-links"><a href="./index-de.html">Start</a><a href="./cv-de.html">CV</a><a href="./ai-lab.html">KI-Ideen im Unterricht</a><a href="./chatbot-de.html">Chatbot</a></nav>
   <div class="nav-links"><button class="btn linkish" data-toggle-theme>🌓</button><a class="btn linkish" href="./portfolio.html">FR</a><a class="btn linkish" href="./portfolio-en.html">EN</a><a class="btn linkish" href="./portfolio-de.html">DE</a></div>
 </div></header>
 

--- a/public/portfolio-en.html
+++ b/public/portfolio-en.html
@@ -9,7 +9,7 @@
 <body>
 <header class="nav"><div class="container">
   <a class="brand" href="./index-en.html"><span class="brand-badge">NT</span><span class="brand-text">Nicolas Tuor</span></a>
-  <nav class="nav-links"><a href="./index-en.html">Home</a><a href="./cv-en.html">CV</a><a href="./ai-lab.html">AI Lab</a><a href="./chatbot-en.html">Chatbot</a></nav>
+  <nav class="nav-links"><a href="./index-en.html">Home</a><a href="./cv-en.html">CV</a><a href="./ai-lab.html">Ideas for AI in Education</a><a href="./chatbot-en.html">Chatbot</a></nav>
   <div class="nav-links"><button class="btn linkish" data-toggle-theme>🌓</button><a class="btn linkish" href="./portfolio.html">FR</a><a class="btn linkish" href="./portfolio-en.html">EN</a><a class="btn linkish" href="./portfolio-de.html">DE</a></div>
 </div></header>
 

--- a/public/portfolio.html
+++ b/public/portfolio.html
@@ -11,7 +11,7 @@
 <header class="nav">
   <div class="container">
     <a class="brand" href="./index.html"><span class="brand-badge">NT</span><span class="brand-text">Nicolas Tuor</span></a>
-    <nav class="nav-links"><a href="./index.html">Accueil</a><a href="./cv.html">CV</a><a href="./ai-lab.html">AI Lab</a><a href="./chatbot.html">Chatbot</a><button id="dlCvBtn" class="btn linkish">Télécharger le CV</button></nav>
+    <nav class="nav-links"><a href="./index.html">Accueil</a><a href="./cv.html">CV</a><a href="./ai-lab.html">Idées IA en éducation</a><a href="./chatbot.html">Chatbot</a><button id="dlCvBtn" class="btn linkish">Télécharger le CV</button></nav>
     <div class="nav-links"><button class="btn linkish" data-toggle-theme>🌓</button><a class="btn linkish" href="./portfolio.html">FR</a><a class="btn linkish" href="./portfolio-en.html">EN</a><a class="btn linkish" href="./portfolio-de.html">DE</a></div>
   </div>
 </header>


### PR DESCRIPTION
## Summary
- update homepage CTAs and instructions to use the requested formal tone in French, English, and German
- align navigation labels, hero titles, and download wording with the canonical phrasing across locales
- refresh CV, portfolio, and chatbot pages with consistent labels and formal placeholders in every language

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c983f419308329b7c86bde16bb8746