### PR TITLE
Uniformiser la navigation des pages publiques

### DIFF
--- a/public/chatbot-de.html
+++ b/public/chatbot-de.html
@@ -17,9 +17,17 @@
 </head>
 <body>
 <header class="nav"><div class="container">
-  <a class="brand" href="./index-de.html"><span class="brand-badge">NT</span><span class="brand-text">Nicolas Tuor</span></a>
-  <nav class="nav-links"><a href="./index-de.html">Start</a><a href="./cv-de.html">CV</a><a href="./portfolio-de.html">Portfolio</a><a href="/ai">KI-Ideen im Unterricht</a></nav>
-  <div class="nav-links"><button class="btn linkish" data-toggle-theme>🌓</button><a class="btn linkish" href="./chatbot.html">FR</a><a class="btn linkish" href="./chatbot-en.html">EN</a><a class="btn linkish" href="./chatbot-de.html">DE</a></div>
+  <a class="brand" href="/"><span class="brand-badge">NT</span><span class="brand-text">Nicolas Tuor</span></a>
+  <nav class="nav-links">
+    <a href="/">Startseite</a>
+    <a href="/portfolio">Portfolio</a>
+    <a href="/cv">Lebenslauf</a>
+    <a href="/chatbot" aria-current="page">Chatbot</a>
+    <a href="/ai">KI-Ideen</a>
+    <a href="/fun-facts">Fun Facts</a>
+    <button class="btn linkish" data-toggle-theme>🌓</button>
+    <a class="btn linkish" href="./chatbot.html">FR</a><a class="btn linkish" href="./chatbot-en.html">EN</a><a class="btn linkish" href="./chatbot-de.html">DE</a>
+  </nav>
 </div></header>
 
 <main class="section container chat">

--- a/public/chatbot-en.html
+++ b/public/chatbot-en.html
@@ -9,9 +9,17 @@
 </head>
 <body>
 <header class="nav"><div class="container">
-  <a class="brand" href="./index-en.html"><span class="brand-badge">NT</span><span class="brand-text">Nicolas Tuor</span></a>
-  <nav class="nav-links"><a href="./index-en.html">Home</a><a href="./cv-en.html">CV</a><a href="./portfolio-en.html">Portfolio</a><a href="/ai">Ideas for AI in Education</a></nav>
-  <div class="nav-links"><button class="btn linkish" data-toggle-theme>🌓</button><a class="btn linkish" href="./chatbot.html">FR</a><a class="btn linkish" href="./chatbot-en.html">EN</a><a class="btn linkish" href="./chatbot-de.html">DE</a></div>
+  <a class="brand" href="/"><span class="brand-badge">NT</span><span class="brand-text">Nicolas Tuor</span></a>
+  <nav class="nav-links">
+    <a href="/">Home</a>
+    <a href="/portfolio">Portfolio</a>
+    <a href="/cv">CV</a>
+    <a href="/chatbot" aria-current="page">Chatbot</a>
+    <a href="/ai">AI Ideas</a>
+    <a href="/fun-facts">Fun Facts</a>
+    <button class="btn linkish" data-toggle-theme>🌓</button>
+    <a class="btn linkish" href="./chatbot.html">FR</a><a class="btn linkish" href="./chatbot-en.html">EN</a><a class="btn linkish" href="./chatbot-de.html">DE</a>
+  </nav>
 </div></header>
 
 <main class="section container chat">

--- a/public/chatbot.html
+++ b/public/chatbot.html
@@ -18,14 +18,17 @@
 <body>
 <header class="nav">
   <div class="container">
-    <a class="brand" href="./index.html"><span class="brand-badge">NT</span><span class="brand-text">Nicolas Tuor</span></a>
+    <a class="brand" href="/"><span class="brand-badge">NT</span><span class="brand-text">Nicolas Tuor</span></a>
     <nav class="nav-links">
-      <a href="./index.html">Accueil</a><a href="./cv.html">CV</a><a href="./portfolio.html">Portfolio</a><a href="/ai">Idées IA en éducation</a>
-    </nav>
-    <div class="nav-links">
+      <a href="/">Accueil</a>
+      <a href="/portfolio">Portfolio</a>
+      <a href="/cv">CV</a>
+      <a href="/chatbot" aria-current="page">Chatbot</a>
+      <a href="/ai">Idées IA</a>
+      <a href="/fun-facts">Fun Facts</a>
       <button class="btn linkish" data-toggle-theme>🌓</button>
       <a class="btn linkish" href="./chatbot.html">FR</a><a class="btn linkish" href="./chatbot-en.html">EN</a><a class="btn linkish" href="./chatbot-de.html">DE</a>
-    </div>
+    </nav>
   </div>
 </header>
 

--- a/public/cv-de.html
+++ b/public/cv-de.html
@@ -9,9 +9,18 @@
 </head>
 <body>
 <header class="nav"><div class="container">
-  <a class="brand" href="./index-de.html"><span class="brand-badge">NT</span><span class="brand-text">Nicolas Tuor</span></a>
-  <nav class="nav-links"><a href="./index-de.html">Start</a><a href="./portfolio-de.html">Portfolio</a><a href="/ai">KI-Ideen im Unterricht</a><a href="./chatbot-de.html">Chatbot</a><button id="dlCvBtn" class="btn linkish">PDF herunterladen</button></nav>
-  <div class="nav-links"><button class="btn linkish" data-toggle-theme>🌓</button><a class="btn linkish" href="./cv.html">FR</a><a class="btn linkish" href="./cv-en.html">EN</a><a class="btn linkish" href="./cv-de.html">DE</a></div>
+  <a class="brand" href="/"><span class="brand-badge">NT</span><span class="brand-text">Nicolas Tuor</span></a>
+  <nav class="nav-links">
+    <a href="/">Startseite</a>
+    <a href="/portfolio">Portfolio</a>
+    <a href="/cv" aria-current="page">Lebenslauf</a>
+    <a href="/chatbot">Chatbot</a>
+    <a href="/ai">KI-Ideen</a>
+    <a href="/fun-facts">Fun Facts</a>
+    <button id="dlCvBtn" class="btn linkish">PDF herunterladen</button>
+    <button class="btn linkish" data-toggle-theme>🌓</button>
+    <a class="btn linkish" href="./cv.html">FR</a><a class="btn linkish" href="./cv-en.html">EN</a><a class="btn linkish" href="./cv-de.html">DE</a>
+  </nav>
 </div></header>
 
 <main class="section container">

--- a/public/cv-en.html
+++ b/public/cv-en.html
@@ -9,9 +9,18 @@
 </head>
 <body>
 <header class="nav"><div class="container">
-  <a class="brand" href="./index-en.html"><span class="brand-badge">NT</span><span class="brand-text">Nicolas Tuor</span></a>
-  <nav class="nav-links"><a href="./index-en.html">Home</a><a href="./portfolio-en.html">Portfolio</a><a href="/ai">Ideas for AI in Education</a><a href="./chatbot-en.html">Chatbot</a><button id="dlCvBtn" class="btn linkish">Download PDF</button></nav>
-  <div class="nav-links"><button class="btn linkish" data-toggle-theme>🌓</button><a class="btn linkish" href="./cv.html">FR</a><a class="btn linkish" href="./cv-en.html">EN</a><a class="btn linkish" href="./cv-de.html">DE</a></div>
+  <a class="brand" href="/"><span class="brand-badge">NT</span><span class="brand-text">Nicolas Tuor</span></a>
+  <nav class="nav-links">
+    <a href="/">Home</a>
+    <a href="/portfolio">Portfolio</a>
+    <a href="/cv" aria-current="page">CV</a>
+    <a href="/chatbot">Chatbot</a>
+    <a href="/ai">AI Ideas</a>
+    <a href="/fun-facts">Fun Facts</a>
+    <button id="dlCvBtn" class="btn linkish">Download PDF</button>
+    <button class="btn linkish" data-toggle-theme>🌓</button>
+    <a class="btn linkish" href="./cv.html">FR</a><a class="btn linkish" href="./cv-en.html">EN</a><a class="btn linkish" href="./cv-de.html">DE</a>
+  </nav>
 </div></header>
 
 <main class="section container">

--- a/public/cv.html
+++ b/public/cv.html
@@ -10,11 +10,14 @@
 <body>
 <header class="nav">
   <div class="container">
-    <a class="brand" href="./index.html"><span class="brand-badge">NT</span><span>Nicolas Tuor</span></a>
+    <a class="brand" href="/"><span class="brand-badge">NT</span><span class="brand-text">Nicolas Tuor</span></a>
     <nav class="nav-links">
-      <a href="./portfolio.html">Portfolio</a>
-      <a href="/ai">Idées IA en éducation</a>
-      <a href="./chatbot.html">Chatbot</a>
+      <a href="/">Accueil</a>
+      <a href="/portfolio">Portfolio</a>
+      <a href="/cv" aria-current="page">CV</a>
+      <a href="/chatbot">Chatbot</a>
+      <a href="/ai">Idées IA</a>
+      <a href="/fun-facts">Fun Facts</a>
       <button id="dlCvBtn" class="btn linkish">Télécharger le CV</button>
       <button class="btn linkish" data-toggle-theme>🌓</button>
     </nav>

--- a/public/fun-facts.html
+++ b/public/fun-facts.html
@@ -42,12 +42,13 @@
 
 <header class="nav">
   <div class="container">
-    <a class="brand" href="./"><span class="brand-badge">NT</span><span class="brand-text">Nicolas Tuor</span></a>
+    <a class="brand" href="/"><span class="brand-badge">NT</span><span class="brand-text">Nicolas Tuor</span></a>
     <nav class="nav-links">
-      <a href="./cv">CV</a>
-      <a href="./portfolio">Portfolio</a>
-      <a href="/ai">Idées IA en éducation</a>
-      <a href="./chatbot">Chatbot</a>
+      <a href="/">Accueil</a>
+      <a href="/portfolio">Portfolio</a>
+      <a href="/cv">CV</a>
+      <a href="/chatbot">Chatbot</a>
+      <a href="/ai">Idées IA</a>
       <a href="/fun-facts" aria-current="page">Fun Facts</a>
       <button class="btn chip" data-toggle-theme title="Thème">◐</button>
     </nav>

--- a/public/game-history.html
+++ b/public/game-history.html
@@ -41,12 +41,14 @@
 
 <header class="nav">
   <div class="container">
-    <a class="brand" href="./"><span class="brand-badge">NT</span><span class="brand-text">Nicolas Tuor</span></a>
+    <a class="brand" href="/"><span class="brand-badge">NT</span><span class="brand-text">Nicolas Tuor</span></a>
     <nav class="nav-links">
-      <a href="./cv">CV</a>
-      <a href="./portfolio">Portfolio</a>
-      <a href="/ai">Idées IA en éducation</a>
-      <a href="./chatbot">Chatbot</a>
+      <a href="/">Accueil</a>
+      <a href="/portfolio">Portfolio</a>
+      <a href="/cv">CV</a>
+      <a href="/chatbot">Chatbot</a>
+      <a href="/ai">Idées IA</a>
+      <a href="/fun-facts">Fun Facts</a>
       <button class="btn chip" data-toggle-theme title="Thème">◐</button>
     </nav>
   </div>

--- a/public/index-de.html
+++ b/public/index-de.html
@@ -11,17 +11,17 @@
 
 <header class="nav">
   <div class="container">
-    <a class="brand" href="./index-de.html">
+    <a class="brand" href="/">
       <span class="brand-badge">NT</span><span class="brand-text">Nicolas Tuor</span>
     </a>
     <nav class="nav-links">
-      <a href="./cv-de.html">CV</a>
-      <a href="./portfolio-de.html">Portfolio</a>
-      <a href="/ai">KI-Ideen im Unterricht</a>
-      <a href="./chatbot-de.html">Chatbot</a>
+      <a href="/" aria-current="page">Startseite</a>
+      <a href="/portfolio">Portfolio</a>
+      <a href="/cv">Lebenslauf</a>
+      <a href="/chatbot">Chatbot</a>
+      <a href="/ai">KI-Ideen</a>
+      <a href="/fun-facts">Fun Facts</a>
       <button id="dlCvBtn" class="btn linkish">PDF herunterladen</button>
-    </nav>
-    <nav class="nav-links">
       <button class="btn linkish" data-toggle-theme title="Theme umschalten">🌓</button>
       <a class="btn linkish" href="./index.html">FR</a>
       <a class="btn linkish" href="./index-en.html">EN</a>

--- a/public/index-en.html
+++ b/public/index-en.html
@@ -11,17 +11,17 @@
 
 <header class="nav">
   <div class="container">
-    <a class="brand" href="./index-en.html">
+    <a class="brand" href="/">
       <span class="brand-badge">NT</span><span class="brand-text">Nicolas Tuor</span>
     </a>
     <nav class="nav-links">
-      <a href="./cv-en.html">CV</a>
-      <a href="./portfolio-en.html">Portfolio</a>
-      <a href="/ai">Ideas for AI in Education</a>
-      <a href="./chatbot-en.html">Chatbot</a>
+      <a href="/" aria-current="page">Home</a>
+      <a href="/portfolio">Portfolio</a>
+      <a href="/cv">CV</a>
+      <a href="/chatbot">Chatbot</a>
+      <a href="/ai">AI Ideas</a>
+      <a href="/fun-facts">Fun Facts</a>
       <button id="dlCvBtn" class="btn linkish">Download PDF</button>
-    </nav>
-    <nav class="nav-links">
       <button class="btn linkish" data-toggle-theme title="Toggle theme">🌓</button>
       <a class="btn linkish" href="./index.html">FR</a>
       <a class="btn linkish is-active" href="./index-en.html">EN</a>

--- a/public/index.html
+++ b/public/index.html
@@ -14,15 +14,17 @@
   <!-- NAV -->
   <header class="nav">
     <div class="container">
-      <a class="brand" href="./">
+      <a class="brand" href="/">
         <span class="brand-badge">NT</span>
         <span class="brand-text">Nicolas Tuor</span>
       </a>
       <nav class="nav-links">
-        <a href="./cv">CV</a>
-        <a href="./portfolio">Portfolio</a>
-        <a href="/ai">Idées IA en éducation</a>
-        <a href="./chatbot">Chatbot</a>
+        <a href="/" aria-current="page">Accueil</a>
+        <a href="/portfolio">Portfolio</a>
+        <a href="/cv">CV</a>
+        <a href="/chatbot">Chatbot</a>
+        <a href="/ai">Idées IA</a>
+        <a href="/fun-facts">Fun Facts</a>
         <button id="themeBtn" class="btn chip" title="Thème">◐</button>
         <a class="btn chip" href="./index.html">FR</a>
         <a class="btn chip" href="./index-en.html">EN</a>

--- a/public/portfolio-de.html
+++ b/public/portfolio-de.html
@@ -9,9 +9,17 @@
 </head>
 <body>
 <header class="nav"><div class="container">
-  <a class="brand" href="./index-de.html"><span class="brand-badge">NT</span><span class="brand-text">Nicolas Tuor</span></a>
-  <nav class="nav-links"><a href="./index-de.html">Start</a><a href="./cv-de.html">CV</a><a href="/ai">KI-Ideen im Unterricht</a><a href="./chatbot-de.html">Chatbot</a></nav>
-  <div class="nav-links"><button class="btn linkish" data-toggle-theme>🌓</button><a class="btn linkish" href="./portfolio.html">FR</a><a class="btn linkish" href="./portfolio-en.html">EN</a><a class="btn linkish" href="./portfolio-de.html">DE</a></div>
+  <a class="brand" href="/"><span class="brand-badge">NT</span><span class="brand-text">Nicolas Tuor</span></a>
+  <nav class="nav-links">
+    <a href="/">Startseite</a>
+    <a href="/portfolio" aria-current="page">Portfolio</a>
+    <a href="/cv">Lebenslauf</a>
+    <a href="/chatbot">Chatbot</a>
+    <a href="/ai">KI-Ideen</a>
+    <a href="/fun-facts">Fun Facts</a>
+    <button class="btn linkish" data-toggle-theme>🌓</button>
+    <a class="btn linkish" href="./portfolio.html">FR</a><a class="btn linkish" href="./portfolio-en.html">EN</a><a class="btn linkish" href="./portfolio-de.html">DE</a>
+  </nav>
 </div></header>
 
 <main class="section container">

--- a/public/portfolio-en.html
+++ b/public/portfolio-en.html
@@ -8,9 +8,17 @@
 </head>
 <body>
 <header class="nav"><div class="container">
-  <a class="brand" href="./index-en.html"><span class="brand-badge">NT</span><span class="brand-text">Nicolas Tuor</span></a>
-  <nav class="nav-links"><a href="./index-en.html">Home</a><a href="./cv-en.html">CV</a><a href="/ai">Ideas for AI in Education</a><a href="./chatbot-en.html">Chatbot</a></nav>
-  <div class="nav-links"><button class="btn linkish" data-toggle-theme>🌓</button><a class="btn linkish" href="./portfolio.html">FR</a><a class="btn linkish" href="./portfolio-en.html">EN</a><a class="btn linkish" href="./portfolio-de.html">DE</a></div>
+  <a class="brand" href="/"><span class="brand-badge">NT</span><span class="brand-text">Nicolas Tuor</span></a>
+  <nav class="nav-links">
+    <a href="/">Home</a>
+    <a href="/portfolio" aria-current="page">Portfolio</a>
+    <a href="/cv">CV</a>
+    <a href="/chatbot">Chatbot</a>
+    <a href="/ai">AI Ideas</a>
+    <a href="/fun-facts">Fun Facts</a>
+    <button class="btn linkish" data-toggle-theme>🌓</button>
+    <a class="btn linkish" href="./portfolio.html">FR</a><a class="btn linkish" href="./portfolio-en.html">EN</a><a class="btn linkish" href="./portfolio-de.html">DE</a>
+  </nav>
 </div></header>
 
 <main class="section container">

--- a/public/portfolio.html
+++ b/public/portfolio.html
@@ -10,9 +10,18 @@
 <body>
 <header class="nav">
   <div class="container">
-    <a class="brand" href="./index.html"><span class="brand-badge">NT</span><span class="brand-text">Nicolas Tuor</span></a>
-    <nav class="nav-links"><a href="./index.html">Accueil</a><a href="./cv.html">CV</a><a href="/ai">Idées IA en éducation</a><a href="./chatbot.html">Chatbot</a><button id="dlCvBtn" class="btn linkish">Télécharger le CV</button></nav>
-    <div class="nav-links"><button class="btn linkish" data-toggle-theme>🌓</button><a class="btn linkish" href="./portfolio.html">FR</a><a class="btn linkish" href="./portfolio-en.html">EN</a><a class="btn linkish" href="./portfolio-de.html">DE</a></div>
+    <a class="brand" href="/"><span class="brand-badge">NT</span><span class="brand-text">Nicolas Tuor</span></a>
+    <nav class="nav-links">
+      <a href="/">Accueil</a>
+      <a href="/portfolio" aria-current="page">Portfolio</a>
+      <a href="/cv">CV</a>
+      <a href="/chatbot">Chatbot</a>
+      <a href="/ai">Idées IA</a>
+      <a href="/fun-facts">Fun Facts</a>
+      <button id="dlCvBtn" class="btn linkish">Télécharger le CV</button>
+      <button class="btn linkish" data-toggle-theme>🌓</button>
+      <a class="btn linkish" href="./portfolio.html">FR</a><a class="btn linkish" href="./portfolio-en.html">EN</a><a class="btn linkish" href="./portfolio-de.html">DE</a>
+    </nav>
   </div>
 </header>
 


### PR DESCRIPTION
## Summary
- Harmonise la barre de navigation des pages publiques françaises avec les six entrées communes et les utilitaires existants.
- Aligne les pages anglaises et allemandes sur la même structure en traduisant les libellés et en conservant les boutons (thème, téléchargement, langue).
- Remplace les liens relatifs par les routes cleanURL partagées sur l’ensemble des fichiers.

## Testing
- No tests were run (not requested).


------
https://chatgpt.com/codex/tasks/task_e_68caa561fd248329b4242b3607a79fc3