### PR TITLE
Update French headers with corrected AI lab link

### DIFF
--- a/public/ai-lab.html
+++ b/public/ai-lab.html
@@ -22,21 +22,22 @@
     </style>
   </head>
   <body>
-    <!-- NAV FR avec lien Idées IA corrigé -->
-    <header class="site-header">
-      <nav class="wrap row" aria-label="Navigation principale">
-        <a href="/" class="btn ghost">Accueil</a>
-        <a href="/portfolio.html" class="btn ghost">Portfolio</a>
-        <a href="/cv.html" class="btn ghost">CV</a>
-        <a href="/chatbot.html" class="btn ghost">Chatbot</a>
-        <a href="/ai-lab.html" class="btn ghost" aria-current="page">Idées IA</a>
-        <a href="/fun-facts.html" class="btn ghost">Fun Facts</a>
-        <span style="flex:1"></span>
-        <a href="/ai-lab.html" class="btn">FR</a>
-        <a href="/ai-lab-en.html" class="btn ghost">EN</a>
-        <a href="/ai-lab-de.html" class="btn ghost">DE</a>
-      </nav>
-    </header>
+<header class="site-header">
+  <nav class="wrap row" aria-label="Navigation principale">
+    <a href="/" class="btn ghost">Accueil</a>
+    <a href="/portfolio.html" class="btn ghost">Portfolio</a>
+    <a href="/cv.html" class="btn ghost">CV</a>
+    <a href="/chatbot.html" class="btn ghost">Chatbot</a>
+    <!-- lien corrigé -->
+    <a href="/ai-lab.html" class="btn ghost">Idées IA</a>
+    <a href="/fun-facts.html" class="btn ghost">Fun Facts</a>
+    <span style="flex:1"></span>
+    <!-- switch langues (même contenu dans EN/DE, libellés traduits) -->
+    <a href="#" class="btn">FR</a>
+    <a href="/ai-lab-en.html" class="btn ghost">EN</a>
+    <a href="/ai-lab-de.html" class="btn ghost">DE</a>
+  </nav>
+</header>
 
     <main class="wrap">
       <h1>Idées IA en éducation — Lab</h1>

--- a/public/chatbot.html
+++ b/public/chatbot.html
@@ -16,27 +16,21 @@
   </style>
 </head>
 <body>
-<header class="nav">
-  <div class="container">
-    <a class="brand" href="/chatbot">
-      <span class="brand-badge">NT</span><span class="brand-text">Nicolas Tuor</span>
-    </a>
-    <nav class="nav-links">
-      <a href="/">Accueil</a>
-      <a href="/portfolio">Portfolio</a>
-      <a href="/cv">CV</a>
-      <a href="/chatbot" aria-current="page">Chatbot</a>
-      <a href="/ai">Idées IA</a>
-      <a href="/fun-facts">Fun Facts</a>
-      <button id="dlCvBtn" class="btn chip" type="button">Télécharger le CV</button>
-      <button class="btn chip" type="button" data-toggle-theme aria-label="Basculer le thème">🌓</button>
-      <span class="lang-switch">
-        <a class="btn chip" href="/chatbot.html" aria-current="page">FR</a>
-        <a class="btn chip" href="/chatbot-en.html">EN</a>
-        <a class="btn chip" href="/chatbot-de.html">DE</a>
-      </span>
-    </nav>
-  </div>
+<header class="site-header">
+  <nav class="wrap row" aria-label="Navigation principale">
+    <a href="/" class="btn ghost">Accueil</a>
+    <a href="/portfolio.html" class="btn ghost">Portfolio</a>
+    <a href="/cv.html" class="btn ghost">CV</a>
+    <a href="/chatbot.html" class="btn ghost">Chatbot</a>
+    <!-- lien corrigé -->
+    <a href="/ai-lab.html" class="btn ghost">Idées IA</a>
+    <a href="/fun-facts.html" class="btn ghost">Fun Facts</a>
+    <span style="flex:1"></span>
+    <!-- switch langues (même contenu dans EN/DE, libellés traduits) -->
+    <a href="#" class="btn">FR</a>
+    <a href="/chatbot-en.html" class="btn ghost">EN</a>
+    <a href="/chatbot-de.html" class="btn ghost">DE</a>
+  </nav>
 </header>
 
 <main class="section container chat">

--- a/public/cv.html
+++ b/public/cv.html
@@ -8,27 +8,21 @@
   <link rel="stylesheet" href="/style.css">
 </head>
 <body>
-<header class="nav">
-  <div class="container">
-    <a class="brand" href="/">
-      <span class="brand-badge">NT</span><span class="brand-text">Nicolas Tuor</span>
-    </a>
-    <nav class="nav-links">
-      <a href="/">Accueil</a>
-      <a href="/portfolio">Portfolio</a>
-      <a href="/cv" aria-current="page">CV</a>
-      <a href="/chatbot">Chatbot</a>
-      <a href="/ai">Idées IA</a>
-      <a href="/fun-facts">Fun Facts</a>
-      <button id="dlCvBtn" class="btn chip" type="button">Télécharger le CV</button>
-      <button class="btn chip" type="button" data-toggle-theme aria-label="Basculer le thème">🌓</button>
-      <span class="lang-switch">
-        <a class="btn chip" href="/cv.html" aria-current="page">FR</a>
-        <a class="btn chip" href="/cv-en.html">EN</a>
-        <a class="btn chip" href="/cv-de.html">DE</a>
-      </span>
-    </nav>
-  </div>
+<header class="site-header">
+  <nav class="wrap row" aria-label="Navigation principale">
+    <a href="/" class="btn ghost">Accueil</a>
+    <a href="/portfolio.html" class="btn ghost">Portfolio</a>
+    <a href="/cv.html" class="btn ghost">CV</a>
+    <a href="/chatbot.html" class="btn ghost">Chatbot</a>
+    <!-- lien corrigé -->
+    <a href="/ai-lab.html" class="btn ghost">Idées IA</a>
+    <a href="/fun-facts.html" class="btn ghost">Fun Facts</a>
+    <span style="flex:1"></span>
+    <!-- switch langues (même contenu dans EN/DE, libellés traduits) -->
+    <a href="#" class="btn">FR</a>
+    <a href="/cv-en.html" class="btn ghost">EN</a>
+    <a href="/cv-de.html" class="btn ghost">DE</a>
+  </nav>
 </header>
 
 <main class="container section">

--- a/public/fun-facts.html
+++ b/public/fun-facts.html
@@ -40,25 +40,21 @@
 </head>
 <body>
 
-<header class="nav">
-  <div class="container">
-    <a class="brand" href="/fun-facts"><span class="brand-badge">NT</span><span class="brand-text">Nicolas Tuor</span></a>
-    <nav class="nav-links">
-      <a href="/">Accueil</a>
-      <a href="/portfolio">Portfolio</a>
-      <a href="/cv">CV</a>
-      <a href="/chatbot">Chatbot</a>
-      <a href="/ai">Idées IA</a>
-      <a href="/fun-facts" aria-current="page">Fun Facts</a>
-      <button id="dlCvBtn" class="btn chip" type="button">Télécharger le CV</button>
-      <button class="btn chip" type="button" data-toggle-theme aria-label="Basculer le thème">🌓</button>
-      <span class="lang-switch">
-        <a class="btn chip" href="/fun-facts.html" aria-current="page">FR</a>
-        <a class="btn chip" href="/fun-facts-en.html">EN</a>
-        <a class="btn chip" href="/fun-facts-de.html">DE</a>
-      </span>
-    </nav>
-  </div>
+<header class="site-header">
+  <nav class="wrap row" aria-label="Navigation principale">
+    <a href="/" class="btn ghost">Accueil</a>
+    <a href="/portfolio.html" class="btn ghost">Portfolio</a>
+    <a href="/cv.html" class="btn ghost">CV</a>
+    <a href="/chatbot.html" class="btn ghost">Chatbot</a>
+    <!-- lien corrigé -->
+    <a href="/ai-lab.html" class="btn ghost">Idées IA</a>
+    <a href="/fun-facts.html" class="btn ghost">Fun Facts</a>
+    <span style="flex:1"></span>
+    <!-- switch langues (même contenu dans EN/DE, libellés traduits) -->
+    <a href="#" class="btn">FR</a>
+    <a href="/fun-facts-en.html" class="btn ghost">EN</a>
+    <a href="/fun-facts-de.html" class="btn ghost">DE</a>
+  </nav>
 </header>
 
 <main class="container section ff-wrap">

--- a/public/index.html
+++ b/public/index.html
@@ -12,28 +12,21 @@
 <body>
 
   <!-- NAV -->
-  <header class="nav">
-    <div class="container">
-      <a class="brand" href="/">
-        <span class="brand-badge">NT</span>
-        <span class="brand-text">Nicolas Tuor</span>
-      </a>
-      <nav class="nav-links">
-        <a href="/" aria-current="page">Accueil</a>
-        <a href="/portfolio">Portfolio</a>
-        <a href="/cv">CV</a>
-        <a href="/chatbot">Chatbot</a>
-        <a href="/ai">Idées IA</a>
-        <a href="/fun-facts">Fun Facts</a>
-        <button id="dlCvBtn" class="btn chip" type="button">Télécharger le CV</button>
-        <button class="btn chip" type="button" data-toggle-theme aria-label="Basculer le thème">🌓</button>
-        <span class="lang-switch">
-          <a class="btn chip" href="/index.html" aria-current="page">FR</a>
-          <a class="btn chip" href="/index-en.html">EN</a>
-          <a class="btn chip" href="/index-de.html">DE</a>
-        </span>
-      </nav>
-    </div>
+  <header class="site-header">
+    <nav class="wrap row" aria-label="Navigation principale">
+      <a href="/" class="btn ghost">Accueil</a>
+      <a href="/portfolio.html" class="btn ghost">Portfolio</a>
+      <a href="/cv.html" class="btn ghost">CV</a>
+      <a href="/chatbot.html" class="btn ghost">Chatbot</a>
+      <!-- lien corrigé -->
+      <a href="/ai-lab.html" class="btn ghost">Idées IA</a>
+      <a href="/fun-facts.html" class="btn ghost">Fun Facts</a>
+      <span style="flex:1"></span>
+      <!-- switch langues (même contenu dans EN/DE, libellés traduits) -->
+      <a href="#" class="btn">FR</a>
+      <a href="/index-en.html" class="btn ghost">EN</a>
+      <a href="/index-de.html" class="btn ghost">DE</a>
+    </nav>
   </header>
 
   <!-- HERO -->

--- a/public/portfolio.html
+++ b/public/portfolio.html
@@ -8,27 +8,21 @@
   <link rel="stylesheet" href="/style.css">
 </head>
 <body>
-<header class="nav">
-  <div class="container">
-    <a class="brand" href="/portfolio">
-      <span class="brand-badge">NT</span><span class="brand-text">Nicolas Tuor</span>
-    </a>
-    <nav class="nav-links">
-      <a href="/">Accueil</a>
-      <a href="/portfolio" aria-current="page">Portfolio</a>
-      <a href="/cv">CV</a>
-      <a href="/chatbot">Chatbot</a>
-      <a href="/ai">Idées IA</a>
-      <a href="/fun-facts">Fun Facts</a>
-      <button id="dlCvBtn" class="btn chip" type="button">Télécharger le CV</button>
-      <button class="btn chip" type="button" data-toggle-theme aria-label="Basculer le thème">🌓</button>
-      <span class="lang-switch">
-        <a class="btn chip" href="/portfolio.html" aria-current="page">FR</a>
-        <a class="btn chip" href="/portfolio-en.html">EN</a>
-        <a class="btn chip" href="/portfolio-de.html">DE</a>
-      </span>
-    </nav>
-  </div>
+<header class="site-header">
+  <nav class="wrap row" aria-label="Navigation principale">
+    <a href="/" class="btn ghost">Accueil</a>
+    <a href="/portfolio.html" class="btn ghost">Portfolio</a>
+    <a href="/cv.html" class="btn ghost">CV</a>
+    <a href="/chatbot.html" class="btn ghost">Chatbot</a>
+    <!-- lien corrigé -->
+    <a href="/ai-lab.html" class="btn ghost">Idées IA</a>
+    <a href="/fun-facts.html" class="btn ghost">Fun Facts</a>
+    <span style="flex:1"></span>
+    <!-- switch langues (même contenu dans EN/DE, libellés traduits) -->
+    <a href="#" class="btn">FR</a>
+    <a href="/portfolio-en.html" class="btn ghost">EN</a>
+    <a href="/portfolio-de.html" class="btn ghost">DE</a>
+  </nav>
 </header>
 
 <main class="section container">


### PR DESCRIPTION
## Summary
- replace the French navigation header on all FR pages with the shared block that links Idées IA to /ai-lab.html

## Testing
- not run (static content)

------
https://chatgpt.com/codex/tasks/task_e_68cac543f4688329a7d59a4672174681