### PR TITLE
Normalize site navigation layout

### DIFF
--- a/public/chatbot-de.html
+++ b/public/chatbot-de.html
@@ -50,22 +50,24 @@
       <div>Nicolas Tuor — <span style="color:#9fb2c8">Informatikdidaktik & verantwortungsvolle KI im Unterricht</span></div>
     </div>
 
-    <nav class="top-actions" aria-label="Navigation principale" style="display:flex;gap:.5rem;flex-wrap:wrap">
-      <a class="btn" href="./index.html">Accueil</a>
-      <a class="btn" href="./cv.html">CV</a>
-      <a class="btn" href="./portfolio.html">Portfolio</a>
-      <a class="btn" href="./chatbot.html">Chatbot</a>
-      <a class="btn" href="./ai-lab-de.html">KI Lab</a>
-      <a class="btn" href="./fun-facts.html">Weit verbreitete Irrtümer</a>
-      <a class="btn" href="./passions.html">Passions</a>
-    </nav>
+    <nav class="top-actions site-nav" aria-label="Navigation principale" style="display:flex;gap:.5rem;flex-wrap:wrap">
+      <ul class="menu">
+        <li><a class="btn" href="./index.html">Accueil</a></li>
+        <li><a class="btn" href="./cv.html">CV</a></li>
+        <li><a class="btn" href="./portfolio.html">Portfolio</a></li>
+        <li><a class="btn" href="./chatbot.html">Chatbot</a></li>
+        <li><a class="btn" href="./ai-lab-de.html">KI Lab</a></li>
+        <li><a class="btn" href="./fun-facts.html">Weit verbreitete Irrtümer</a></li>
+        <li><a class="btn" href="./passions.html">Passions</a></li>
+      </ul>
 
-    <!-- Switcher de langue (liens directs vers la même page si elle existe) -->
-    <nav class="lang" aria-label="Langue" style="display:flex;gap:.35rem;flex-wrap:wrap">
-      <!-- Sur passions.html, ces 3 liens pointent vers passions(.html|-en|-de) -->
-      <a class="btn" href="./passions.html" aria-current="page">FR</a>
-      <a class="btn" href="./passions-en.html">EN</a>
-      <a class="btn" href="./passions-de.html">DE</a>
+      <!-- Switcher de langue (liens directs vers la même page si elle existe) -->
+      <ul class="lang" style="display:flex;gap:.35rem;flex-wrap:wrap">
+        <!-- Sur passions.html, ces 3 liens pointent vers passions(.html|-en|-de) -->
+        <li><a class="btn" href="./passions.html" aria-current="page">FR</a></li>
+        <li><a class="btn" href="./passions-en.html">EN</a></li>
+        <li><a class="btn" href="./passions-de.html">DE</a></li>
+      </ul>
     </nav>
   </div>
 </header>

--- a/public/chatbot-en.html
+++ b/public/chatbot-en.html
@@ -50,22 +50,24 @@
       <div>Nicolas Tuor — <span style="color:#9fb2c8">Computer Science Didactics & Education</span></div>
     </div>
 
-    <nav class="top-actions" aria-label="Navigation principale" style="display:flex;gap:.5rem;flex-wrap:wrap">
-      <a class="btn" href="./index.html">Accueil</a>
-      <a class="btn" href="./cv.html">CV</a>
-      <a class="btn" href="./portfolio.html">Portfolio</a>
-      <a class="btn" href="./chatbot.html">Chatbot</a>
-      <a class="btn" href="./ai-lab-en.html">AI Lab</a>
-      <a class="btn" href="./fun-facts.html">Common misconceptions</a>
-      <a class="btn" href="./passions.html">Passions</a>
-    </nav>
+    <nav class="top-actions site-nav" aria-label="Navigation principale" style="display:flex;gap:.5rem;flex-wrap:wrap">
+      <ul class="menu">
+        <li><a class="btn" href="./index.html">Accueil</a></li>
+        <li><a class="btn" href="./cv.html">CV</a></li>
+        <li><a class="btn" href="./portfolio.html">Portfolio</a></li>
+        <li><a class="btn" href="./chatbot.html">Chatbot</a></li>
+        <li><a class="btn" href="./ai-lab-en.html">AI Lab</a></li>
+        <li><a class="btn" href="./fun-facts.html">Common misconceptions</a></li>
+        <li><a class="btn" href="./passions.html">Passions</a></li>
+      </ul>
 
-    <!-- Switcher de langue (liens directs vers la même page si elle existe) -->
-    <nav class="lang" aria-label="Langue" style="display:flex;gap:.35rem;flex-wrap:wrap">
-      <!-- Sur passions.html, ces 3 liens pointent vers passions(.html|-en|-de) -->
-      <a class="btn" href="./passions.html" aria-current="page">FR</a>
-      <a class="btn" href="./passions-en.html">EN</a>
-      <a class="btn" href="./passions-de.html">DE</a>
+      <!-- Switcher de langue (liens directs vers la même page si elle existe) -->
+      <ul class="lang" style="display:flex;gap:.35rem;flex-wrap:wrap">
+        <!-- Sur passions.html, ces 3 liens pointent vers passions(.html|-en|-de) -->
+        <li><a class="btn" href="./passions.html" aria-current="page">FR</a></li>
+        <li><a class="btn" href="./passions-en.html">EN</a></li>
+        <li><a class="btn" href="./passions-de.html">DE</a></li>
+      </ul>
     </nav>
   </div>
 </header>

--- a/public/chatbot.html
+++ b/public/chatbot.html
@@ -66,20 +66,22 @@
 <body>
   <!-- NAVBAR ajoutée -->
   <header class="navbar">
-    <div class="nav-left">
-      <a class="chip" href="/">Accueil</a>
-      <a class="chip" href="/portfolio">Portfolio</a>
-      <a class="chip" href="/cv">CV</a>
-      <a class="chip" href="/chatbot">Chatbot</a>
-      <a class="chip" href="/ai-lab">Applications IA</a>
-      <a class="chip" href="/fun-facts">Idées reçues</a>
-    </div>
-    <div class="nav-right">
-      <a class="chip" href="/chatbot">FR</a>
-      <a class="chip" href="/chatbot-en">EN</a>
-      <a class="chip" href="/chatbot-de">DE</a>
-      <button id="themeToggle" class="toggle" type="button" aria-label="Basculer thème">🌙 Mode nuit</button>
-    </div>
+    <nav class="site-nav">
+      <ul class="menu nav-left">
+        <li><a class="chip" href="/">Accueil</a></li>
+        <li><a class="chip" href="/portfolio">Portfolio</a></li>
+        <li><a class="chip" href="/cv">CV</a></li>
+        <li><a class="chip" href="/chatbot">Chatbot</a></li>
+        <li><a class="chip" href="/ai-lab">Applications IA</a></li>
+        <li><a class="chip" href="/fun-facts">Idées reçues</a></li>
+        <li><button id="themeToggle" class="toggle" type="button" aria-label="Basculer thème">🌙 Mode nuit</button></li>
+      </ul>
+      <ul class="lang nav-right">
+        <li><a class="chip" href="/chatbot">FR</a></li>
+        <li><a class="chip" href="/chatbot-en">EN</a></li>
+        <li><a class="chip" href="/chatbot-de">DE</a></li>
+      </ul>
+    </nav>
   </header>
 
   <main class="container">

--- a/public/game-history.html
+++ b/public/game-history.html
@@ -44,20 +44,22 @@
     <a class="brand" href="/">
       <span class="brand-badge">NT</span><span class="brand-text">Nicolas Tuor</span>
     </a>
-    <nav class="nav-links">
-      <a href="/">Accueil</a>
-      <a href="/portfolio">Portfolio</a>
-      <a href="/cv">CV</a>
-      <a href="/chatbot">Chatbot</a>
-      <a href="/ai">Idées IA</a>
-      <a href="/fun-facts">Fun Facts</a>
-      <button id="dlCvBtn" class="btn chip" type="button">Télécharger le CV</button>
-      <button class="btn chip" type="button" data-toggle-theme aria-label="Basculer le thème">🌓</button>
-      <span class="lang-switch">
-        <a class="btn chip" href="/game-history.html" aria-current="page">FR</a>
-        <a class="btn chip" href="/game-history.html">EN</a>
-        <a class="btn chip" href="/game-history.html">DE</a>
-      </span>
+    <nav class="nav-links site-nav">
+      <ul class="menu">
+        <li><a href="/">Accueil</a></li>
+        <li><a href="/portfolio">Portfolio</a></li>
+        <li><a href="/cv">CV</a></li>
+        <li><a href="/chatbot">Chatbot</a></li>
+        <li><a href="/ai">Idées IA</a></li>
+        <li><a href="/fun-facts">Fun Facts</a></li>
+        <li><button id="dlCvBtn" class="btn chip" type="button">Télécharger le CV</button></li>
+        <li><button class="btn chip" type="button" data-toggle-theme aria-label="Basculer le thème">🌓</button></li>
+      </ul>
+      <ul class="lang lang-switch">
+        <li><a class="btn chip" href="/game-history.html" aria-current="page">FR</a></li>
+        <li><a class="btn chip" href="/game-history.html">EN</a></li>
+        <li><a class="btn chip" href="/game-history.html">DE</a></li>
+      </ul>
     </nav>
   </div>
 </header>

--- a/public/style.css
+++ b/public/style.css
@@ -452,3 +452,39 @@ a:focus-visible {
   .site-nav { flex-wrap: wrap; white-space: normal; }
   .site-nav .menu { flex: 1 1 auto; flex-wrap: wrap; }
 }
+
+/* === UPDATE: NAV LAYOUT NORMALIZATION — placement only === */
+.site-nav {
+  position: static !important;
+  float: none !important;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: clamp(0.5rem, 1vw, 1rem);
+  white-space: nowrap;
+  margin: 0 0 var(--space-2, 1rem) 0;
+}
+
+.site-nav .menu {
+  display: flex;
+  gap: clamp(0.5rem, 1vw, 0.75rem);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.site-nav .lang {
+  display: flex;
+  gap: 0.5rem;
+  margin: 0 0 0 auto;
+  padding: 0;
+  list-style: none;
+}
+
+/* Mobile: autoriser un wrap propre si l’espace manque, en gardant les langues à droite */
+@media (max-width: 620px) {
+  .site-nav { flex-wrap: wrap; white-space: normal; }
+  .site-nav .menu { flex: 1 1 auto; flex-wrap: wrap; }
+  .site-nav .lang { margin-left: auto; }
+}


### PR DESCRIPTION
## Summary
- refactor chatbot and game history headers so their `<nav>` blocks share the common menu/lang list structure and `.site-nav` class
- append the provided navigation placement CSS rules to the global stylesheet so menus stay on one line with language links on the right

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d137d5cae883299ac3a32f55bfc8df