### PR TITLE
Normalize header navigation layout

### DIFF
--- a/public/ai-lab-de.html
+++ b/public/ai-lab-de.html
@@ -31,7 +31,8 @@
   <header class="nav">
     <div class="container">
       <a class="brand" href="/ai-lab-de.html"><span class="brand-badge">NT</span><span class="brand-text">Nicolas Tuor</span></a>
-      <nav class="nav-links site-nav">
+      <!-- UPDATE: NAV LAYOUT ONLY -->
+      <nav class="site-nav" aria-label="Navigation">
         <ul class="menu">
           <li><a href="/index-de.html">Startseite</a></li>
           <li><a href="/cv-de.html">Lebenslauf</a></li>

--- a/public/ai-lab-en.html
+++ b/public/ai-lab-en.html
@@ -31,7 +31,8 @@
   <header class="nav">
     <div class="container">
       <a class="brand" href="/ai-lab-en.html"><span class="brand-badge">NT</span><span class="brand-text">Nicolas Tuor</span></a>
-      <nav class="nav-links site-nav">
+      <!-- UPDATE: NAV LAYOUT ONLY -->
+      <nav class="site-nav" aria-label="Navigation">
         <ul class="menu">
           <li><a href="/index-en.html">Home</a></li>
           <li><a href="/cv-en.html">CV</a></li>

--- a/public/ai-lab.html
+++ b/public/ai-lab.html
@@ -23,7 +23,8 @@
 </head>
 <body>
 <header class="site-header">
-  <nav class="wrap row site-nav">
+  <!-- UPDATE: NAV LAYOUT ONLY -->
+  <nav class="site-nav">
     <ul class="menu">
       <li><a href="/index.html" class="btn ghost">Accueil</a></li>
       <li><a href="/cv.html" class="btn ghost">CV</a></li>

--- a/public/cv-de.html
+++ b/public/cv-de.html
@@ -86,7 +86,8 @@
       <div class="logo">N·T</div>
       <div>CV — Nicolas Tuor</div>
     </div>
-    <nav class="top site-nav" aria-label="Navigation">
+    <!-- UPDATE: NAV LAYOUT ONLY -->
+    <nav class="site-nav" aria-label="Navigation">
       <ul class="menu">
         <li><a class="btn" href="/index-de.html">Startseite</a></li>
         <li><a class="btn" href="/cv-de.html" aria-current="page" style="border-color:#1e3a5f;background:#10223a">Lebenslauf</a></li>

--- a/public/cv-en.html
+++ b/public/cv-en.html
@@ -41,7 +41,8 @@
 
   <!-- Unified header (same as portfolio) -->
   <header class="site-header">
-    <nav class="wrap row site-nav" aria-label="Main navigation">
+    <!-- UPDATE: NAV LAYOUT ONLY -->
+    <nav class="site-nav" aria-label="Main navigation">
       <ul class="menu">
         <li><a href="/index-en.html" class="btn ghost">Home</a></li>
         <li><a href="/cv-en.html" class="btn" aria-current="page">CV</a></li>

--- a/public/cv.html
+++ b/public/cv.html
@@ -41,7 +41,8 @@
 
   <!-- Header harmonisé (comme portfolio) -->
   <header class="site-header">
-    <nav class="wrap row site-nav" aria-label="Navigation principale">
+    <!-- UPDATE: NAV LAYOUT ONLY -->
+    <nav class="site-nav" aria-label="Navigation principale">
       <ul class="menu">
         <li><a href="/index.html" class="btn ghost">Accueil</a></li>
         <li><a href="/cv.html" class="btn" aria-current="page">CV</a></li>

--- a/public/fun-facts-de.html
+++ b/public/fun-facts-de.html
@@ -48,7 +48,8 @@
 <header class="nav">
   <div class="container">
     <a class="brand" href="/fun-facts-de.html"><span class="brand-badge">NT</span><span class="brand-text">Nicolas Tuor</span></a>
-    <nav class="nav-links site-nav">
+    <!-- UPDATE: NAV LAYOUT ONLY -->
+    <nav class="site-nav" aria-label="Navigation">
       <ul class="menu">
         <li><a href="/index-de.html">Startseite</a></li>
         <li><a href="/cv-de.html">Lebenslauf</a></li>

--- a/public/fun-facts-en.html
+++ b/public/fun-facts-en.html
@@ -48,7 +48,8 @@
 <header class="nav">
   <div class="container">
     <a class="brand" href="/fun-facts-en.html"><span class="brand-badge">NT</span><span class="brand-text">Nicolas Tuor</span></a>
-    <nav class="nav-links site-nav">
+    <!-- UPDATE: NAV LAYOUT ONLY -->
+    <nav class="site-nav" aria-label="Navigation">
       <ul class="menu">
         <li><a href="/index-en.html">Home</a></li>
         <li><a href="/cv-en.html">CV</a></li>

--- a/public/fun-facts.html
+++ b/public/fun-facts.html
@@ -81,7 +81,8 @@
 <body>
   <!-- NAV -->
   <header class="navbar">
-    <nav class="site-nav">
+    <!-- UPDATE: NAV LAYOUT ONLY -->
+    <nav class="site-nav" aria-label="Navigation">
       <ul class="menu nav-left">
         <li><a class="chip" href="/index.html">Accueil</a></li>
         <li><a class="chip" href="/cv.html">CV</a></li>

--- a/public/index-de.html
+++ b/public/index-de.html
@@ -21,7 +21,8 @@
       <div>Nicolas Tuor — <span style="color:#9fb2c8">Informatikdidaktik & verantwortungsvolle KI im Unterricht</span></div>
     </div>
 
-    <nav class="top-actions site-nav" aria-label="Navigation principale" style="display:flex;gap:.5rem;flex-wrap:wrap">
+    <!-- UPDATE: NAV LAYOUT ONLY -->
+    <nav class="site-nav" aria-label="Navigation principale">
       <ul class="menu">
         <li><a href="/index-de.html" aria-current="page">Startseite</a></li>
         <li><a href="/cv-de.html">Lebenslauf</a></li>

--- a/public/index-en.html
+++ b/public/index-en.html
@@ -21,7 +21,8 @@
       <div>Nicolas Tuor — <span style="color:#9fb2c8">Computer Science Didactics & Education</span></div>
     </div>
 
-    <nav class="top-actions site-nav" aria-label="Navigation principale" style="display:flex;gap:.5rem;flex-wrap:wrap">
+    <!-- UPDATE: NAV LAYOUT ONLY -->
+    <nav class="site-nav" aria-label="Navigation principale">
       <ul class="menu">
         <li><a href="/index-en.html" aria-current="page">Home</a></li>
         <li><a href="/cv-en.html">CV</a></li>

--- a/public/index.html
+++ b/public/index.html
@@ -180,7 +180,8 @@
       <div>Nicolas Tuor — <span style="color:var(--muted)">éducation, sciences & technologies</span></div>
     </div>
 
-    <nav class="top-actions site-nav" aria-label="Navigation">
+    <!-- UPDATE: NAV LAYOUT ONLY -->
+    <nav class="site-nav" aria-label="Navigation">
       <ul class="menu">
         <li><a href="/index.html" aria-current="page">Accueil</a></li>
         <li><a href="/cv.html">CV</a></li>

--- a/public/passions-de.html
+++ b/public/passions-de.html
@@ -58,7 +58,8 @@
 <header>
   <div class="headwrap">
     <div class="brand"><div class="logo">N·T</div><div>Leidenschaften & Entdeckungen</div></div>
-    <nav class="top site-nav" aria-label="Navigation">
+    <!-- UPDATE: NAV LAYOUT ONLY -->
+    <nav class="site-nav" aria-label="Navigation">
       <ul class="menu">
         <li><a class="btn" href="/index-de.html">Startseite</a></li>
         <li><a class="btn" href="/cv-de.html">Lebenslauf</a></li>

--- a/public/passions-en.html
+++ b/public/passions-en.html
@@ -58,7 +58,8 @@
 <header>
   <div class="headwrap">
     <div class="brand"><div class="logo">N·T</div><div>Passions & discoveries</div></div>
-    <nav class="top site-nav" aria-label="Navigation">
+    <!-- UPDATE: NAV LAYOUT ONLY -->
+    <nav class="site-nav" aria-label="Navigation">
       <ul class="menu">
         <li><a class="btn" href="/index-en.html">Home</a></li>
         <li><a class="btn" href="/cv-en.html">CV</a></li>

--- a/public/passions.html
+++ b/public/passions.html
@@ -77,7 +77,8 @@
 <header>
   <div class="headwrap">
     <div class="brand"><div class="logo">N·T</div><div>Passions & découvertes</div></div>
-    <nav class="top site-nav" aria-label="Navigation">
+    <!-- UPDATE: NAV LAYOUT ONLY -->
+    <nav class="site-nav" aria-label="Navigation">
       <ul class="menu">
         <li><a class="btn" href="/index.html">Accueil</a></li>
         <li><a class="btn" href="/cv.html">CV</a></li>

--- a/public/style.css
+++ b/public/style.css
@@ -413,48 +413,8 @@ a:focus-visible {
 }
 .chat .row input#q::placeholder { opacity: .8; }
 
-/* === UPDATE: NAV NORMALIZATION (layout only) === */
-.site-nav {
-  display: flex;
-  align-items: center;
-  justify-content: flex-start;
-  gap: 1rem;
-  white-space: nowrap;
-}
-
-.site-nav .menu {
-  display: flex;
-  gap: 0.75rem;
-  margin: 0;
-  padding: 0;
-  list-style: none;
-}
-
-.site-nav .lang {
-  display: flex;
-  gap: 0.5rem;
-  margin: 0 0 0 auto;
-  padding: 0;
-  list-style: none;
-}
-
-.site-nav li { list-style: none; }
-.site-nav li::marker { content: ""; }
-.site-nav .dot,
-.site-nav .bullet { display: none; }
-
-.site-nav a[aria-current="page"] {
-  border-radius: var(--radius-pill, 9999px);
-  outline: var(--focus-ring, none);
-}
-
-@media (max-width: 980px) {
-  .site-nav { flex-wrap: wrap; white-space: normal; }
-  .site-nav .menu { flex: 1 1 auto; flex-wrap: wrap; }
-}
-
-/* === UPDATE: NAV LAYOUT NORMALIZATION — placement only === */
-.site-nav {
+/* === NAV-PLACEMENT-ONLY (DO NOT TOUCH OTHER STYLES) === */
+header .site-nav {
   position: static !important;
   float: none !important;
   width: 100%;
@@ -463,28 +423,28 @@ a:focus-visible {
   justify-content: flex-start;
   gap: clamp(0.5rem, 1vw, 1rem);
   white-space: nowrap;
-  margin: 0 0 var(--space-2, 1rem) 0;
+  margin: 0 0 var(--space-2, 1rem);
 }
-
-.site-nav .menu {
+header .site-nav .menu {
   display: flex;
   gap: clamp(0.5rem, 1vw, 0.75rem);
   margin: 0;
   padding: 0;
   list-style: none;
 }
-
-.site-nav .lang {
+header .site-nav .lang {
   display: flex;
   gap: 0.5rem;
   margin: 0 0 0 auto;
   padding: 0;
   list-style: none;
 }
+header .site-nav li { list-style: none; }
+header .site-nav li::marker { content: ""; }
 
-/* Mobile: autoriser un wrap propre si l’espace manque, en gardant les langues à droite */
+/* Mobile: wrap propre si manque d’espace, langues restent à droite */
 @media (max-width: 620px) {
-  .site-nav { flex-wrap: wrap; white-space: normal; }
-  .site-nav .menu { flex: 1 1 auto; flex-wrap: wrap; }
-  .site-nav .lang { margin-left: auto; }
+  header .site-nav { flex-wrap: wrap; white-space: normal; }
+  header .site-nav .menu { flex: 1 1 auto; flex-wrap: wrap; }
+  header .site-nav .lang { margin-left: auto; }
 }


### PR DESCRIPTION
## Summary
- standardize the header navigation markup across the index, CV, Passions, AI Lab, and Fun Facts pages (FR/EN/DE) so each uses the unified `.site-nav` block with menu and language lists
- update the shared stylesheet with the required NAV-PLACEMENT-ONLY rules to align menus to the left and language pills to the right

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d13a5307408329962d1c6926bb8c70