### PR TITLE
Normalize site navigation placement

### DIFF
--- a/public/ai-lab.html
+++ b/public/ai-lab.html
@@ -24,7 +24,7 @@
 <body>
 <header class="site-header">
   <!-- UPDATE: NAV LAYOUT ONLY -->
-  <nav class="site-nav">
+  <nav class="site-nav" aria-label="Navigation">
     <ul class="menu">
       <li><a href="/index.html" class="btn ghost">Accueil</a></li>
       <li><a href="/cv.html" class="btn ghost">CV</a></li>

--- a/public/chatbot-de.html
+++ b/public/chatbot-de.html
@@ -44,13 +44,7 @@
 </head>
 <body>
  <header aria-label="En-tête">
-  <div class="headwrap" style="max-width:1200px;margin:0 auto;padding:12px 18px;display:flex;gap:12px;align-items:center;justify-content:space-between">
-    <div class="brand" style="display:flex;align-items:center;gap:.75rem;font-weight:800;letter-spacing:.3px">
-      <div class="logo" style="width:32px;height:32px;border-radius:9px;display:grid;place-items:center;background:linear-gradient(135deg,#0a1220,#00060d);color:#fff;border:1px solid rgba(255,255,255,.08);box-shadow:inset 0 0 0 1px rgba(255,255,255,.04)">N·T</div>
-      <div>Nicolas Tuor — <span style="color:#9fb2c8">Informatikdidaktik & verantwortungsvolle KI im Unterricht</span></div>
-    </div>
-
-    <nav class="top-actions site-nav" aria-label="Navigation principale" style="display:flex;gap:.5rem;flex-wrap:wrap">
+    <nav class="site-nav" aria-label="Navigation">
       <ul class="menu">
         <li><a class="btn" href="./index.html">Accueil</a></li>
         <li><a class="btn" href="./cv.html">CV</a></li>
@@ -62,15 +56,18 @@
       </ul>
 
       <!-- Switcher de langue (liens directs vers la même page si elle existe) -->
-      <ul class="lang" style="display:flex;gap:.35rem;flex-wrap:wrap">
+      <ul class="lang">
         <!-- Sur passions.html, ces 3 liens pointent vers passions(.html|-en|-de) -->
         <li><a class="btn" href="./passions.html" aria-current="page">FR</a></li>
         <li><a class="btn" href="./passions-en.html">EN</a></li>
         <li><a class="btn" href="./passions-de.html">DE</a></li>
       </ul>
     </nav>
-  </div>
-</header>
+    <div class="brand" style="display:flex;align-items:center;gap:.75rem;font-weight:800;letter-spacing:.3px">
+      <div class="logo" style="width:32px;height:32px;border-radius:9px;display:grid;place-items:center;background:linear-gradient(135deg,#0a1220,#00060d);color:#fff;border:1px solid rgba(255,255,255,.08);box-shadow:inset 0 0 0 1px rgba(255,255,255,.04)">N·T</div>
+      <div>Nicolas Tuor — <span style="color:#9fb2c8">Informatikdidaktik & verantwortungsvolle KI im Unterricht</span></div>
+    </div>
+  </header>
 
 
   <main class="container">

--- a/public/chatbot-en.html
+++ b/public/chatbot-en.html
@@ -44,13 +44,7 @@
 </head>
 <body>
   <header aria-label="En-tête">
-  <div class="headwrap" style="max-width:1200px;margin:0 auto;padding:12px 18px;display:flex;gap:12px;align-items:center;justify-content:space-between">
-    <div class="brand" style="display:flex;align-items:center;gap:.75rem;font-weight:800;letter-spacing:.3px">
-      <div class="logo" style="width:32px;height:32px;border-radius:9px;display:grid;place-items:center;background:linear-gradient(135deg,#0a1220,#00060d);color:#fff;border:1px solid rgba(255,255,255,.08);box-shadow:inset 0 0 0 1px rgba(255,255,255,.04)">N·T</div>
-      <div>Nicolas Tuor — <span style="color:#9fb2c8">Computer Science Didactics & Education</span></div>
-    </div>
-
-    <nav class="top-actions site-nav" aria-label="Navigation principale" style="display:flex;gap:.5rem;flex-wrap:wrap">
+    <nav class="site-nav" aria-label="Navigation">
       <ul class="menu">
         <li><a class="btn" href="./index.html">Accueil</a></li>
         <li><a class="btn" href="./cv.html">CV</a></li>
@@ -62,15 +56,18 @@
       </ul>
 
       <!-- Switcher de langue (liens directs vers la même page si elle existe) -->
-      <ul class="lang" style="display:flex;gap:.35rem;flex-wrap:wrap">
+      <ul class="lang">
         <!-- Sur passions.html, ces 3 liens pointent vers passions(.html|-en|-de) -->
         <li><a class="btn" href="./passions.html" aria-current="page">FR</a></li>
         <li><a class="btn" href="./passions-en.html">EN</a></li>
         <li><a class="btn" href="./passions-de.html">DE</a></li>
       </ul>
     </nav>
-  </div>
-</header>
+    <div class="brand" style="display:flex;align-items:center;gap:.75rem;font-weight:800;letter-spacing:.3px">
+      <div class="logo" style="width:32px;height:32px;border-radius:9px;display:grid;place-items:center;background:linear-gradient(135deg,#0a1220,#00060d);color:#fff;border:1px solid rgba(255,255,255,.08);box-shadow:inset 0 0 0 1px rgba(255,255,255,.04)">N·T</div>
+      <div>Nicolas Tuor — <span style="color:#9fb2c8">Computer Science Didactics & Education</span></div>
+    </div>
+  </header>
 
 
   <main class="container">

--- a/public/chatbot.html
+++ b/public/chatbot.html
@@ -66,8 +66,8 @@
 <body>
   <!-- NAVBAR ajoutée -->
   <header class="navbar">
-    <nav class="site-nav">
-      <ul class="menu nav-left">
+    <nav class="site-nav" aria-label="Navigation">
+      <ul class="menu">
         <li><a class="chip" href="/">Accueil</a></li>
         <li><a class="chip" href="/portfolio">Portfolio</a></li>
         <li><a class="chip" href="/cv">CV</a></li>
@@ -76,7 +76,7 @@
         <li><a class="chip" href="/fun-facts">Idées reçues</a></li>
         <li><button id="themeToggle" class="toggle" type="button" aria-label="Basculer thème">🌙 Mode nuit</button></li>
       </ul>
-      <ul class="lang nav-right">
+      <ul class="lang">
         <li><a class="chip" href="/chatbot">FR</a></li>
         <li><a class="chip" href="/chatbot-en">EN</a></li>
         <li><a class="chip" href="/chatbot-de">DE</a></li>

--- a/public/cv-en.html
+++ b/public/cv-en.html
@@ -42,7 +42,7 @@
   <!-- Unified header (same as portfolio) -->
   <header class="site-header">
     <!-- UPDATE: NAV LAYOUT ONLY -->
-    <nav class="site-nav" aria-label="Main navigation">
+    <nav class="site-nav" aria-label="Navigation">
       <ul class="menu">
         <li><a href="/index-en.html" class="btn ghost">Home</a></li>
         <li><a href="/cv-en.html" class="btn" aria-current="page">CV</a></li>

--- a/public/cv.html
+++ b/public/cv.html
@@ -42,7 +42,7 @@
   <!-- Header harmonisé (comme portfolio) -->
   <header class="site-header">
     <!-- UPDATE: NAV LAYOUT ONLY -->
-    <nav class="site-nav" aria-label="Navigation principale">
+    <nav class="site-nav" aria-label="Navigation">
       <ul class="menu">
         <li><a href="/index.html" class="btn ghost">Accueil</a></li>
         <li><a href="/cv.html" class="btn" aria-current="page">CV</a></li>

--- a/public/fun-facts.html
+++ b/public/fun-facts.html
@@ -83,7 +83,7 @@
   <header class="navbar">
     <!-- UPDATE: NAV LAYOUT ONLY -->
     <nav class="site-nav" aria-label="Navigation">
-      <ul class="menu nav-left">
+      <ul class="menu">
         <li><a class="chip" href="/index.html">Accueil</a></li>
         <li><a class="chip" href="/cv.html">CV</a></li>
         <li><a class="chip" href="/portfolio.html">Portfolio</a></li>
@@ -91,7 +91,7 @@
         <li><a class="chip" href="/ai-lab.html">Labo IA</a></li>
         <li><a class="chip" href="/fun-facts.html" aria-current="page">Idées reçues</a></li>
       </ul>
-      <ul class="lang nav-right">
+      <ul class="lang">
         <li><a class="chip" href="/fun-facts.html" aria-current="page">FR</a></li>
         <li><a class="chip" href="/fun-facts-en.html">EN</a></li>
         <li><a class="chip" href="/fun-facts-de.html">DE</a></li>

--- a/public/game-history.html
+++ b/public/game-history.html
@@ -44,7 +44,7 @@
     <a class="brand" href="/">
       <span class="brand-badge">NT</span><span class="brand-text">Nicolas Tuor</span>
     </a>
-    <nav class="nav-links site-nav">
+    <nav class="site-nav" aria-label="Navigation">
       <ul class="menu">
         <li><a href="/">Accueil</a></li>
         <li><a href="/portfolio">Portfolio</a></li>
@@ -55,7 +55,7 @@
         <li><button id="dlCvBtn" class="btn chip" type="button">Télécharger le CV</button></li>
         <li><button class="btn chip" type="button" data-toggle-theme aria-label="Basculer le thème">🌓</button></li>
       </ul>
-      <ul class="lang lang-switch">
+      <ul class="lang">
         <li><a class="btn chip" href="/game-history.html" aria-current="page">FR</a></li>
         <li><a class="btn chip" href="/game-history.html">EN</a></li>
         <li><a class="btn chip" href="/game-history.html">DE</a></li>

--- a/public/index-de.html
+++ b/public/index-de.html
@@ -15,14 +15,8 @@
 <body>
 
 <header aria-label="En-tête">
-  <div class="headwrap" style="max-width:1200px;margin:0 auto;padding:12px 18px;display:flex;gap:12px;align-items:center;justify-content:space-between">
-    <div class="brand" style="display:flex;align-items:center;gap:.75rem;font-weight:800;letter-spacing:.3px">
-      <div class="logo" style="width:32px;height:32px;border-radius:9px;display:grid;place-items:center;background:linear-gradient(135deg,#0a1220,#00060d);color:#fff;border:1px solid rgba(255,255,255,.08);box-shadow:inset 0 0 0 1px rgba(255,255,255,.04)">N·T</div>
-      <div>Nicolas Tuor — <span style="color:#9fb2c8">Informatikdidaktik & verantwortungsvolle KI im Unterricht</span></div>
-    </div>
-
-    <!-- UPDATE: NAV LAYOUT ONLY -->
-    <nav class="site-nav" aria-label="Navigation principale">
+  <!-- UPDATE: NAV LAYOUT ONLY -->
+  <nav class="site-nav" aria-label="Navigation">
       <ul class="menu">
         <li><a href="/index-de.html" aria-current="page">Startseite</a></li>
         <li><a href="/cv-de.html">Lebenslauf</a></li>
@@ -37,6 +31,9 @@
         <li><a href="/index-de.html" aria-current="page">DE</a></li>
       </ul>
     </nav>
+  <div class="brand" style="display:flex;align-items:center;gap:.75rem;font-weight:800;letter-spacing:.3px">
+    <div class="logo" style="width:32px;height:32px;border-radius:9px;display:grid;place-items:center;background:linear-gradient(135deg,#0a1220,#00060d);color:#fff;border:1px solid rgba(255,255,255,.08);box-shadow:inset 0 0 0 1px rgba(255,255,255,.04)">N·T</div>
+    <div>Nicolas Tuor — <span style="color:#9fb2c8">Informatikdidaktik & verantwortungsvolle KI im Unterricht</span></div>
   </div>
 </header>
 

--- a/public/index-en.html
+++ b/public/index-en.html
@@ -15,14 +15,8 @@
 <body>
 
 <header aria-label="En-tête">
-  <div class="headwrap" style="max-width:1200px;margin:0 auto;padding:12px 18px;display:flex;gap:12px;align-items:center;justify-content:space-between">
-    <div class="brand" style="display:flex;align-items:center;gap:.75rem;font-weight:800;letter-spacing:.3px">
-      <div class="logo" style="width:32px;height:32px;border-radius:9px;display:grid;place-items:center;background:linear-gradient(135deg,#0a1220,#00060d);color:#fff;border:1px solid rgba(255,255,255,.08);box-shadow:inset 0 0 0 1px rgba(255,255,255,.04)">N·T</div>
-      <div>Nicolas Tuor — <span style="color:#9fb2c8">Computer Science Didactics & Education</span></div>
-    </div>
-
-    <!-- UPDATE: NAV LAYOUT ONLY -->
-    <nav class="site-nav" aria-label="Navigation principale">
+  <!-- UPDATE: NAV LAYOUT ONLY -->
+  <nav class="site-nav" aria-label="Navigation">
       <ul class="menu">
         <li><a href="/index-en.html" aria-current="page">Home</a></li>
         <li><a href="/cv-en.html">CV</a></li>
@@ -37,6 +31,9 @@
         <li><a href="/index-de.html">DE</a></li>
       </ul>
     </nav>
+  <div class="brand" style="display:flex;align-items:center;gap:.75rem;font-weight:800;letter-spacing:.3px">
+    <div class="logo" style="width:32px;height:32px;border-radius:9px;display:grid;place-items:center;background:linear-gradient(135deg,#0a1220,#00060d);color:#fff;border:1px solid rgba(255,255,255,.08);box-shadow:inset 0 0 0 1px rgba(255,255,255,.04)">N·T</div>
+    <div>Nicolas Tuor — <span style="color:#9fb2c8">Computer Science Didactics & Education</span></div>
   </div>
 </header>
 

--- a/public/index.html
+++ b/public/index.html
@@ -175,11 +175,6 @@
 </head>
 <body class="panel-collapsed">
   <header aria-label="En-tête">
-    <div class="brand">
-      <div class="logo" aria-hidden="true">N·T</div>
-      <div>Nicolas Tuor — <span style="color:var(--muted)">éducation, sciences & technologies</span></div>
-    </div>
-
     <!-- UPDATE: NAV LAYOUT ONLY -->
     <nav class="site-nav" aria-label="Navigation">
       <ul class="menu">
@@ -196,6 +191,11 @@
         <li><a href="/index-de.html">DE</a></li>
       </ul>
     </nav>
+
+    <div class="brand">
+      <div class="logo" aria-hidden="true">N·T</div>
+      <div>Nicolas Tuor — <span style="color:var(--muted)">éducation, sciences & technologies</span></div>
+    </div>
   </header>
 
   <main>

--- a/public/portfolio-de.html
+++ b/public/portfolio-de.html
@@ -70,7 +70,7 @@
 <header>
   <div class="headwrap">
     <div class="brand"><div class="logo">N·T</div><div>Leidenschaften & Entdeckungen</div></div>
-    <nav class="top site-nav" aria-label="Navigation">
+    <nav class="site-nav" aria-label="Navigation">
       <ul class="menu">
         <li><a class="btn" href="/index-de.html">Startseite</a></li>
         <li><a class="btn" href="/cv-de.html">Lebenslauf</a></li>
@@ -79,7 +79,7 @@
         <li><a class="btn" href="/ai-lab-de.html">KI-Lab</a></li>
         <li><a class="btn" href="/fun-facts-de.html">Irrtümer</a></li>
       </ul>
-      <ul class="lang" style="display:flex;gap:.35rem;flex-wrap:wrap;margin-left:.5rem">
+      <ul class="lang">
         <li><a class="btn" href="/portfolio.html">FR</a></li>
         <li><a class="btn" href="/portfolio-en.html">EN</a></li>
         <li><a class="btn" href="/portfolio-de.html" aria-current="page">DE</a></li>

--- a/public/portfolio-en.html
+++ b/public/portfolio-en.html
@@ -18,7 +18,7 @@
     <a class="brand" href="/portfolio-en.html">
       <span class="brand-badge">NT</span><span class="brand-text">Nicolas Tuor</span>
     </a>
-    <nav class="nav-links site-nav">
+    <nav class="site-nav" aria-label="Navigation">
       <ul class="menu">
         <li><a href="/index-en.html">Home</a></li>
         <li><a href="/cv-en.html">CV</a></li>

--- a/public/portfolio.html
+++ b/public/portfolio.html
@@ -37,7 +37,7 @@
 </head>
 <body>
   <header class="site-header">
-    <nav class="wrap row site-nav" aria-label="Navigation principale" style="padding:10px 16px">
+    <nav class="site-nav" aria-label="Navigation">
       <ul class="menu">
         <li><a href="/index.html" class="btn ghost">Accueil</a></li>
         <li><a href="/cv.html" class="btn ghost">CV</a></li>

--- a/public/style.css
+++ b/public/style.css
@@ -413,38 +413,32 @@ a:focus-visible {
 }
 .chat .row input#q::placeholder { opacity: .8; }
 
-/* === NAV-PLACEMENT-ONLY (DO NOT TOUCH OTHER STYLES) === */
-header .site-nav {
-  position: static !important;
-  float: none !important;
-  width: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: flex-start;
+/* === UPDATE: NAV LAYOUT NORMALIZATION — placement only === */
+.site-nav{
+  display:flex;
+  align-items:center;
   gap: clamp(0.5rem, 1vw, 1rem);
+  width:100%;
+  /* pas de position/fixed ici: on respecte le header existant (sticky, fixed, etc.) */
   white-space: nowrap;
-  margin: 0 0 var(--space-2, 1rem);
 }
-header .site-nav .menu {
-  display: flex;
-  gap: clamp(0.5rem, 1vw, 0.75rem);
-  margin: 0;
-  padding: 0;
-  list-style: none;
-}
-header .site-nav .lang {
-  display: flex;
-  gap: 0.5rem;
-  margin: 0 0 0 auto;
-  padding: 0;
-  list-style: none;
-}
-header .site-nav li { list-style: none; }
-header .site-nav li::marker { content: ""; }
 
-/* Mobile: wrap propre si manque d’espace, langues restent à droite */
-@media (max-width: 620px) {
-  header .site-nav { flex-wrap: wrap; white-space: normal; }
-  header .site-nav .menu { flex: 1 1 auto; flex-wrap: wrap; }
-  header .site-nav .lang { margin-left: auto; }
+.site-nav .menu,
+.site-nav .lang{
+  display:flex;
+  gap: clamp(0.5rem, 1vw, 0.75rem);
+  margin:0;
+  padding:0;
+  list-style:none;
+}
+
+.site-nav .lang{
+  margin-left:auto; /* pousse FR·EN·DE à droite */
+}
+
+/* Mobile: autoriser un wrap propre si l’espace manque, en gardant les langues à droite */
+@media (max-width: 620px){
+  .site-nav{ flex-wrap: wrap; white-space: normal; }
+  .site-nav .menu{ flex:1 1 auto; flex-wrap: wrap; }
+  .site-nav .lang{ margin-left:auto; }
 }


### PR DESCRIPTION
## Summary
- update the localized landing pages and key sections to share a single `.site-nav` block with unified menu and language lists
- append the shared navigation flex layout rules to the global stylesheet

## Testing
- not run (static changes)


------
https://chatgpt.com/codex/tasks/task_e_68d13fff2a208329a06d64c9e27da6ef