### PR TITLE
Add missing global stylesheet link to public pages

### DIFF
--- a/public/ai-lab-de.html
+++ b/public/ai-lab-de.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>KI-Ideen für den Unterricht</title>
-  <link rel="stylesheet" href="/style.css" />
   <!-- UPDATE: hreflang -->
   <link rel="alternate" hreflang="fr" href="/ai-lab.html">
   <link rel="alternate" hreflang="en" href="/ai-lab-en.html">
@@ -26,6 +25,7 @@
     .loader.show{display:flex}
     .pill{display:inline-flex;align-items:center;gap:8px;padding:.25rem .6rem;border-radius:999px;border:1px solid #1a4573;background:#0b223a;color:#cfe4ff}
   </style>
+  <link rel="stylesheet" href="/style.css">
   <script defer src="/assets/js/nav.js"></script>
 </head>
 <body>

--- a/public/ai-lab-en.html
+++ b/public/ai-lab-en.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>AI Ideas for education</title>
-  <link rel="stylesheet" href="/style.css" />
   <!-- UPDATE: hreflang -->
   <link rel="alternate" hreflang="fr" href="/ai-lab.html">
   <link rel="alternate" hreflang="en" href="/ai-lab-en.html">
@@ -26,6 +25,7 @@
     .loader.show{display:flex}
     .pill{display:inline-flex;align-items:center;gap:8px;padding:.25rem .6rem;border-radius:999px;border:1px solid #1a4573;background:#0b223a;color:#cfe4ff}
   </style>
+  <link rel="stylesheet" href="/style.css">
   <script defer src="/assets/js/nav.js"></script>
 </head>
 <body>

--- a/public/ai-lab.html
+++ b/public/ai-lab.html
@@ -6,7 +6,6 @@
   <title>Idées IA — Lab</title>
   <meta name="description" content="Générateur de quiz PER et mini-jeu pédagogiques."/>
   <link rel="icon" href="/favicon.ico"/><!-- si 404, remplace par /icon.svg existant -->
-  <link rel="stylesheet" href="/style.css"/>
   <!-- UPDATE: hreflang -->
   <link rel="alternate" hreflang="fr" href="/ai-lab.html">
   <link rel="alternate" hreflang="en" href="/ai-lab-en.html">
@@ -20,6 +19,7 @@
     #qOutput pre{white-space:pre-wrap;word-break:break-word}
     #osselets-root{min-height:320px}
   </style>
+  <link rel="stylesheet" href="/style.css">
   <script defer src="/assets/js/nav.js"></script>
 </head>
 <body>

--- a/public/chatbot-de.html
+++ b/public/chatbot-de.html
@@ -5,7 +5,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>KI-Chatbot — Nicolas Tuor</title>
   <link rel="icon" href="/favicon.ico">
-  <link rel="stylesheet" href="/style.css">
   <style>
     :root{ --bg:#081521; --panel:#0b2237; --ink:#e6f1ff; --muted:#cfe2ff; --bd:#ffffff22; --accent:#3aa7ff; --chip-bg:#0d2a45; --chip-bd:#ffffff22; }
     html[data-theme="light"]{ --bg:#f7f9fc; --panel:#ffffff; --ink:#0b2237; --muted:#244c6e; --bd:#0b223733; --accent:#0b66d6; --chip-bg:#eef4fb; --chip-bd:#0b223722; }
@@ -41,6 +40,7 @@
     .legacy{display:none}
     @media (max-width:720px){ #chatLog{height:52vh} .controls{gap:10px} }
   </style>
+  <link rel="stylesheet" href="/style.css">
   <script defer src="/assets/js/nav.js"></script>
 </head>
 <body>

--- a/public/chatbot-en.html
+++ b/public/chatbot-en.html
@@ -5,7 +5,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>AI Chatbot — Nicolas Tuor</title>
   <link rel="icon" href="/favicon.ico">
-  <link rel="stylesheet" href="/style.css">
   <style>
     :root{ --bg:#081521; --panel:#0b2237; --ink:#e6f1ff; --muted:#cfe2ff; --bd:#ffffff22; --accent:#3aa7ff; --chip-bg:#0d2a45; --chip-bd:#ffffff22; }
     html[data-theme="light"]{ --bg:#f7f9fc; --panel:#ffffff; --ink:#0b2237; --muted:#244c6e; --bd:#0b223733; --accent:#0b66d6; --chip-bg:#eef4fb; --chip-bd:#0b223722; }
@@ -41,6 +40,7 @@
     .legacy{display:none}
     @media (max-width:720px){ #chatLog{height:52vh} .controls{gap:10px} }
   </style>
+  <link rel="stylesheet" href="/style.css">
   <script defer src="/assets/js/nav.js"></script>
 </head>
 <body>

--- a/public/chatbot.html
+++ b/public/chatbot.html
@@ -5,7 +5,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Chatbot IA — Nicolas Tuor</title>
   <link rel="icon" href="/favicon.ico">
-  <link rel="stylesheet" href="/style.css">
   <style>
     :root{
       --bg:#081521; --panel:#0b2237; --ink:#e6f1ff; --muted:#cfe2ff; --bd:#ffffff22; --accent:#3aa7ff;
@@ -62,6 +61,7 @@
       .controls{gap:10px}
     }
   </style>
+  <link rel="stylesheet" href="/style.css">
   <script defer src="/assets/js/nav.js"></script>
 </head>
 <body>

--- a/public/cv-de.html
+++ b/public/cv-de.html
@@ -78,6 +78,7 @@
     address{font-style:normal}
     hr{height:1px; border:0; background:rgba(255,255,255,.08); margin:10px 0}
   </style>
+  <link rel="stylesheet" href="/style.css">
   <script defer src="/assets/js/nav.js"></script>
 </head>
 <body>

--- a/public/cv-en.html
+++ b/public/cv-en.html
@@ -36,6 +36,7 @@
              background:#0b1323; border-radius:var(--br); overflow:hidden }
     .viewer object{ width:100%; height:100%; border:0; display:block }
   </style>
+  <link rel="stylesheet" href="/style.css">
   <script defer src="/assets/js/nav.js"></script>
 </head>
 <body>

--- a/public/cv.html
+++ b/public/cv.html
@@ -36,6 +36,7 @@
              background:#0b1323; border-radius:var(--br); overflow:hidden }
     .viewer object{ width:100%; height:100%; border:0; display:block }
   </style>
+  <link rel="stylesheet" href="/style.css">
   <script defer src="/assets/js/nav.js"></script>
 </head>
 <body>

--- a/public/fun-facts-de.html
+++ b/public/fun-facts-de.html
@@ -5,7 +5,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <title>Fun Facts — Irrtümer & bewiesene Fakten</title>
   <link rel="icon" href="/favicon.svg"/>
-  <link rel="stylesheet" href="/style.css"/>
   <!-- UPDATE: hreflang -->
   <link rel="alternate" hreflang="fr" href="/fun-facts.html">
   <link rel="alternate" hreflang="en" href="/fun-facts-en.html">
@@ -42,6 +41,7 @@
   </style>
   <script defer src="/site.js"></script>
   <script defer src="/fun-facts.js"></script>
+  <link rel="stylesheet" href="/style.css">
   <script defer src="/assets/js/nav.js"></script>
 </head>
 <body>

--- a/public/fun-facts-en.html
+++ b/public/fun-facts-en.html
@@ -5,7 +5,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <title>Fun Facts — Misconceptions & Verified facts</title>
   <link rel="icon" href="/favicon.svg"/>
-  <link rel="stylesheet" href="/style.css"/>
   <!-- UPDATE: hreflang -->
   <link rel="alternate" hreflang="fr" href="/fun-facts.html">
   <link rel="alternate" hreflang="en" href="/fun-facts-en.html">
@@ -42,6 +41,7 @@
   </style>
   <script defer src="/site.js"></script>
   <script defer src="/fun-facts.js"></script>
+  <link rel="stylesheet" href="/style.css">
   <script defer src="/assets/js/nav.js"></script>
 </head>
 <body>

--- a/public/fun-facts.html
+++ b/public/fun-facts.html
@@ -5,7 +5,6 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Fun Facts — Nicolas Tuor</title>
   <link rel="icon" href="/favicon.ico" />
-  <link rel="stylesheet" href="/style.css" />
   <!-- UPDATE: hreflang -->
   <link rel="alternate" hreflang="fr" href="/fun-facts.html">
   <link rel="alternate" hreflang="en" href="/fun-facts-en.html">
@@ -77,6 +76,7 @@
 
   <script defer src="/confetti.js"></script>
   <script defer src="/fun-facts.js"></script>
+  <link rel="stylesheet" href="/style.css">
   <script defer src="/assets/js/nav.js"></script>
 </head>
 <body>

--- a/public/game-history.html
+++ b/public/game-history.html
@@ -5,7 +5,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Histoire Aventure — Platformer IA</title>
   <link rel="icon" href="/favicon.svg" />
-  <link rel="stylesheet" href="/style.css" />
   <style>
     /* Styles spécifiques au jeu (légers) */
     .gh-wrap { display:grid; gap:14px; }
@@ -36,6 +35,7 @@
   </style>
   <script defer src="/site.js"></script>
   <script defer src="/game-history.js"></script>
+  <link rel="stylesheet" href="/style.css">
   <script defer src="/assets/js/nav.js"></script>
 </head>
 <body>

--- a/public/index-de.html
+++ b/public/index-de.html
@@ -5,12 +5,12 @@
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Nicolas Tuor — Informatikdidaktik & verantwortungsvolle KI im Unterricht</title>
-  <link rel="stylesheet" href="/style.css" />
   <!-- UPDATE: hreflang -->
   <link rel="alternate" hreflang="fr" href="/index.html">
   <link rel="alternate" hreflang="en" href="/index-en.html">
   <link rel="alternate" hreflang="de" href="/index-de.html">
   <link rel="alternate" hreflang="x-default" href="/index.html">
+  <link rel="stylesheet" href="/style.css">
   <script defer src="/assets/js/nav.js"></script>
 </head>
 <body>

--- a/public/index-en.html
+++ b/public/index-en.html
@@ -5,12 +5,12 @@
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Nicolas Tuor — Computer Science Didactics & Education</title>
-  <link rel="stylesheet" href="/style.css" />
   <!-- UPDATE: hreflang -->
   <link rel="alternate" hreflang="fr" href="/index.html">
   <link rel="alternate" hreflang="en" href="/index-en.html">
   <link rel="alternate" hreflang="de" href="/index-de.html">
   <link rel="alternate" hreflang="x-default" href="/index.html">
+  <link rel="stylesheet" href="/style.css">
   <script defer src="/assets/js/nav.js"></script>
 </head>
 <body>

--- a/public/index.html
+++ b/public/index.html
@@ -172,6 +172,7 @@
       .panel-toggle-btn{ inset:-12px auto auto 18px; border-radius:12px; }
     }
   </style>
+  <link rel="stylesheet" href="/style.css">
   <script defer src="/assets/js/nav.js"></script>
 </head>
 <body class="panel-collapsed">

--- a/public/passions-de.html
+++ b/public/passions-de.html
@@ -53,6 +53,7 @@
     .thumb[data-cover]{background-image:linear-gradient(180deg,#0d1524,#0a1220)}
     .thumb.loaded{background-image:var(--img)}
   </style>
+  <link rel="stylesheet" href="/style.css">
   <script defer src="/assets/js/nav.js"></script>
 </head>
 <body>

--- a/public/passions-en.html
+++ b/public/passions-en.html
@@ -53,6 +53,7 @@
     .thumb[data-cover]{background-image:linear-gradient(180deg,#0d1524,#0a1220)}
     .thumb.loaded{background-image:var(--img)}
   </style>
+  <link rel="stylesheet" href="/style.css">
   <script defer src="/assets/js/nav.js"></script>
 </head>
 <body>

--- a/public/passions.html
+++ b/public/passions.html
@@ -72,6 +72,7 @@
     .thumb[data-cover]{background-image:linear-gradient(180deg,#0d1524,#0a1220)}
     .thumb.loaded{background-image:var(--img)}
   </style>
+  <link rel="stylesheet" href="/style.css">
   <script defer src="/assets/js/nav.js"></script>
 </head>
 <body>

--- a/public/portfolio-de.html
+++ b/public/portfolio-de.html
@@ -65,6 +65,7 @@
     .thumb[data-cover]{background-image:linear-gradient(180deg,#0d1524,#0a1220)}
     .thumb.loaded{background-image:var(--img)}
   </style>
+  <link rel="stylesheet" href="/style.css">
   <script defer src="/assets/js/nav.js"></script>
 </head>
 <body>

--- a/public/portfolio-en.html
+++ b/public/portfolio-en.html
@@ -5,12 +5,12 @@
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Portfolio — Nicolas Tuor</title>
-  <link rel="stylesheet" href="/style.css">
   <!-- UPDATE: hreflang -->
   <link rel="alternate" hreflang="fr" href="/portfolio.html">
   <link rel="alternate" hreflang="en" href="/portfolio-en.html">
   <link rel="alternate" hreflang="de" href="/portfolio-de.html">
   <link rel="alternate" hreflang="x-default" href="/portfolio.html">
+  <link rel="stylesheet" href="/style.css">
   <script defer src="/assets/js/nav.js"></script>
 </head>
 <body>

--- a/public/portfolio.html
+++ b/public/portfolio.html
@@ -6,7 +6,6 @@
   <title>Portfolio — Nicolas Tuor</title>
   <meta name="description" content="Projets et démos (éducation, IA, jeux pédagogiques)."/>
   <link rel="icon" href="/favicon.ico"/>
-  <link rel="stylesheet" href="/style.css"/>
   <!-- UPDATE: hreflang -->
   <link rel="alternate" hreflang="fr" href="/portfolio.html">
   <link rel="alternate" hreflang="en" href="/portfolio-en.html">
@@ -34,6 +33,7 @@
                              padding:10px 12px; border-bottom:1px solid #ffffff22; color:#fff; }
     .overlay iframe { width:100%; height: calc(100% - 46px); border:0; background:#fff; }
   </style>
+  <link rel="stylesheet" href="/style.css">
   <script defer src="/assets/js/nav.js"></script>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- ensure every public HTML page loads `/style.css` from the `<head>`
- place the stylesheet link immediately before the deferred navigation script
- remove duplicate `<link rel="stylesheet" href="/style.css">` entries

## Testing
- no tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d14cdbdb248329beae7f72756bb3db