### PR TITLE
Adjust index headers below global nav

### DIFF
--- a/public/index-de.html
+++ b/public/index-de.html
@@ -12,6 +12,25 @@
   <link rel="alternate" hreflang="x-default" href="/index.html">
   <link rel="stylesheet" href="/style.css">
   <script defer src="/assets/js/nav.js"></script>
+  <style>
+    /* ===== Header : brand | buttons ===== */
+    /* // UPDATE: décale le titre sous la nav globale */
+    :root { --navH: 56px; }                /* hauteur approx. de la nav en desktop */
+    @media (max-width: 820px){ :root { --navH: 72px; } }  /* nav peut passer à 2 lignes */
+
+    header{
+      position: fixed;
+      left: 18px;
+      right: 18px;
+      top: calc(18px + var(--navH));   /* était 18px → on ajoute la hauteur de la nav */
+      z-index: 5;                      /* sous #nt-global-nav (qui est au-dessus) */
+      display:flex; align-items:center; justify-content:space-between; gap:1rem;
+    }
+
+    /* // UPDATE: si un ancien nav local existe dans ce header, on le masque.
+       (#nt-global-nav est en dehors du header, donc non impacté) */
+    header > nav.site-nav { display: none; }
+  </style>
 </head>
 <body>
 

--- a/public/index-en.html
+++ b/public/index-en.html
@@ -12,6 +12,25 @@
   <link rel="alternate" hreflang="x-default" href="/index.html">
   <link rel="stylesheet" href="/style.css">
   <script defer src="/assets/js/nav.js"></script>
+  <style>
+    /* ===== Header : brand | buttons ===== */
+    /* // UPDATE: décale le titre sous la nav globale */
+    :root { --navH: 56px; }                /* hauteur approx. de la nav en desktop */
+    @media (max-width: 820px){ :root { --navH: 72px; } }  /* nav peut passer à 2 lignes */
+
+    header{
+      position: fixed;
+      left: 18px;
+      right: 18px;
+      top: calc(18px + var(--navH));   /* était 18px → on ajoute la hauteur de la nav */
+      z-index: 5;                      /* sous #nt-global-nav (qui est au-dessus) */
+      display:flex; align-items:center; justify-content:space-between; gap:1rem;
+    }
+
+    /* // UPDATE: si un ancien nav local existe dans ce header, on le masque.
+       (#nt-global-nav est en dehors du header, donc non impacté) */
+    header > nav.site-nav { display: none; }
+  </style>
 </head>
 <body>
 

--- a/public/index.html
+++ b/public/index.html
@@ -41,10 +41,22 @@
     }
 
     /* ===== Header : brand | boutons ===== */
+    /* // UPDATE: décale le titre sous la nav globale */
+    :root { --navH: 56px; }                /* hauteur approx. de la nav en desktop */
+    @media (max-width: 820px){ :root { --navH: 72px; } }  /* nav peut passer à 2 lignes */
+
     header{
-      position:fixed; inset:18px 18px auto 18px; z-index:10;
+      position: fixed;
+      left: 18px;
+      right: 18px;
+      top: calc(18px + var(--navH));   /* était 18px → on ajoute la hauteur de la nav */
+      z-index: 5;                      /* sous #nt-global-nav (qui est au-dessus) */
       display:flex; align-items:center; justify-content:space-between; gap:1rem;
     }
+
+    /* // UPDATE: si un ancien nav local existe dans ce header, on le masque.
+       (#nt-global-nav est en dehors du header, donc non impacté) */
+    header > nav.site-nav { display: none; }
     .brand{
       display:flex; align-items:center; gap:.75rem;
       padding:.6rem .8rem; border-radius:14px;


### PR DESCRIPTION
## Summary
- offset the local headers on all index pages so they render beneath the global navigation bar
- hide any legacy in-header navigation to avoid overlap with the global menu

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d150622e3c8329a3cfcd0015157e0f