### PR TITLE
Fix header overlap with global navigation

### DIFF
--- a/public/assets/js/nav.js
+++ b/public/assets/js/nav.js
@@ -78,6 +78,14 @@
 
   // Monte le header tout en haut du body
   document.body.prepend(header);
+  // // UPDATE: expose la hauteur réelle de la nav -> CSS var --nt-nav-h
+  function setNavHeight() {
+    const h = Math.ceil(header.getBoundingClientRect().height);
+    document.documentElement.style.setProperty('--nt-nav-h', h + 'px');
+  }
+  setNavHeight();
+  window.addEventListener('load', setNavHeight);
+  window.addEventListener('resize', setNavHeight);
   document.body.classList.add('nt-nav-mounted');
 
   // Masque les anciens navs (sans supprimer le HTML)

--- a/public/index-de.html
+++ b/public/index-de.html
@@ -18,18 +18,18 @@
     :root { --navH: 56px; }                /* hauteur approx. de la nav en desktop */
     @media (max-width: 820px){ :root { --navH: 72px; } }  /* nav peut passer à 2 lignes */
 
+    /* // UPDATE: brand sous la nav globale, quelle que soit sa hauteur */
     header{
       position: fixed;
       left: 18px;
       right: 18px;
-      top: calc(18px + var(--navH));   /* était 18px → on ajoute la hauteur de la nav */
-      z-index: 5;                      /* sous #nt-global-nav (qui est au-dessus) */
+      top: calc(18px + var(--nt-nav-h, 64px)); /* hauteur dynamique, fallback 64px */
+      z-index: 5; /* sous #nt-global-nav (z-index:100) */
       display:flex; align-items:center; justify-content:space-between; gap:1rem;
     }
 
-    /* // UPDATE: si un ancien nav local existe dans ce header, on le masque.
-       (#nt-global-nav est en dehors du header, donc non impacté) */
-    header > nav.site-nav { display: none; }
+    /* masque l'ancien nav local s'il subsiste dans ce header */
+    header > nav.site-nav { display: none !important; }
   </style>
 </head>
 <body>

--- a/public/index-en.html
+++ b/public/index-en.html
@@ -18,18 +18,18 @@
     :root { --navH: 56px; }                /* hauteur approx. de la nav en desktop */
     @media (max-width: 820px){ :root { --navH: 72px; } }  /* nav peut passer à 2 lignes */
 
+    /* // UPDATE: brand sous la nav globale, quelle que soit sa hauteur */
     header{
       position: fixed;
       left: 18px;
       right: 18px;
-      top: calc(18px + var(--navH));   /* était 18px → on ajoute la hauteur de la nav */
-      z-index: 5;                      /* sous #nt-global-nav (qui est au-dessus) */
+      top: calc(18px + var(--nt-nav-h, 64px)); /* hauteur dynamique, fallback 64px */
+      z-index: 5; /* sous #nt-global-nav (z-index:100) */
       display:flex; align-items:center; justify-content:space-between; gap:1rem;
     }
 
-    /* // UPDATE: si un ancien nav local existe dans ce header, on le masque.
-       (#nt-global-nav est en dehors du header, donc non impacté) */
-    header > nav.site-nav { display: none; }
+    /* masque l'ancien nav local s'il subsiste dans ce header */
+    header > nav.site-nav { display: none !important; }
   </style>
 </head>
 <body>

--- a/public/index.html
+++ b/public/index.html
@@ -45,18 +45,18 @@
     :root { --navH: 56px; }                /* hauteur approx. de la nav en desktop */
     @media (max-width: 820px){ :root { --navH: 72px; } }  /* nav peut passer à 2 lignes */
 
+    /* // UPDATE: brand sous la nav globale, quelle que soit sa hauteur */
     header{
       position: fixed;
       left: 18px;
       right: 18px;
-      top: calc(18px + var(--navH));   /* était 18px → on ajoute la hauteur de la nav */
-      z-index: 5;                      /* sous #nt-global-nav (qui est au-dessus) */
+      top: calc(18px + var(--nt-nav-h, 64px)); /* hauteur dynamique, fallback 64px */
+      z-index: 5; /* sous #nt-global-nav (z-index:100) */
       display:flex; align-items:center; justify-content:space-between; gap:1rem;
     }
 
-    /* // UPDATE: si un ancien nav local existe dans ce header, on le masque.
-       (#nt-global-nav est en dehors du header, donc non impacté) */
-    header > nav.site-nav { display: none; }
+    /* masque l'ancien nav local s'il subsiste dans ce header */
+    header > nav.site-nav { display: none !important; }
     .brand{
       display:flex; align-items:center; gap:.75rem;
       padding:.6rem .8rem; border-radius:14px;

--- a/public/style.css
+++ b/public/style.css
@@ -483,3 +483,6 @@ a:focus-visible {
   #nt-global-nav .menu { flex: 1 1 auto; }
   #nt-global-nav .lang  { margin-left: auto; }
 }
+
+/* // UPDATE: place la nav globale au-dessus de tout */
+#nt-global-nav { position: relative; z-index: 100; }


### PR DESCRIPTION
## Summary
- ensure the injected global navigation stays on top by giving #nt-global-nav a higher stacking context
- expose the computed navigation height as a CSS custom property so pages can offset their headers dynamically
- update FR/EN/DE landing pages to position their fixed headers below the global nav and hide any legacy nav markup

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d155f7f9d88329a2b3be1169f3befa