### PR TITLE
Add feedback script to public pages

### DIFF
--- a/public/ai-lab-de.html
+++ b/public/ai-lab-de.html
@@ -27,6 +27,7 @@
   </style>
   <link rel="stylesheet" href="/style.css">
   <script defer src="/assets/js/nav.js"></script>
+  <script defer src="/assets/js/feedback.js"></script>
 </head>
 <body>
   <header class="nav">

--- a/public/ai-lab-en.html
+++ b/public/ai-lab-en.html
@@ -27,6 +27,7 @@
   </style>
   <link rel="stylesheet" href="/style.css">
   <script defer src="/assets/js/nav.js"></script>
+  <script defer src="/assets/js/feedback.js"></script>
 </head>
 <body>
   <header class="nav">

--- a/public/ai-lab.html
+++ b/public/ai-lab.html
@@ -21,6 +21,7 @@
   </style>
   <link rel="stylesheet" href="/style.css">
   <script defer src="/assets/js/nav.js"></script>
+  <script defer src="/assets/js/feedback.js"></script>
 </head>
 <body>
 <header class="site-header">

--- a/public/chatbot-de.html
+++ b/public/chatbot-de.html
@@ -42,6 +42,7 @@
   </style>
   <link rel="stylesheet" href="/style.css">
   <script defer src="/assets/js/nav.js"></script>
+  <script defer src="/assets/js/feedback.js"></script>
 </head>
 <body>
  <header aria-label="En-tête">

--- a/public/chatbot-en.html
+++ b/public/chatbot-en.html
@@ -42,6 +42,7 @@
   </style>
   <link rel="stylesheet" href="/style.css">
   <script defer src="/assets/js/nav.js"></script>
+  <script defer src="/assets/js/feedback.js"></script>
 </head>
 <body>
   <header aria-label="En-tête">

--- a/public/chatbot.html
+++ b/public/chatbot.html
@@ -63,6 +63,7 @@
   </style>
   <link rel="stylesheet" href="/style.css">
   <script defer src="/assets/js/nav.js"></script>
+  <script defer src="/assets/js/feedback.js"></script>
 </head>
 <body>
   <!-- NAVBAR ajoutée -->

--- a/public/cv-de.html
+++ b/public/cv-de.html
@@ -80,6 +80,7 @@
   </style>
   <link rel="stylesheet" href="/style.css">
   <script defer src="/assets/js/nav.js"></script>
+  <script defer src="/assets/js/feedback.js"></script>
 </head>
 <body>
 <header>

--- a/public/cv-en.html
+++ b/public/cv-en.html
@@ -38,6 +38,7 @@
   </style>
   <link rel="stylesheet" href="/style.css">
   <script defer src="/assets/js/nav.js"></script>
+  <script defer src="/assets/js/feedback.js"></script>
 </head>
 <body>
 

--- a/public/cv.html
+++ b/public/cv.html
@@ -38,6 +38,7 @@
   </style>
   <link rel="stylesheet" href="/style.css">
   <script defer src="/assets/js/nav.js"></script>
+  <script defer src="/assets/js/feedback.js"></script>
 </head>
 <body>
 

--- a/public/fun-facts-de.html
+++ b/public/fun-facts-de.html
@@ -43,6 +43,7 @@
   <script defer src="/fun-facts.js"></script>
   <link rel="stylesheet" href="/style.css">
   <script defer src="/assets/js/nav.js"></script>
+  <script defer src="/assets/js/feedback.js"></script>
 </head>
 <body>
 

--- a/public/fun-facts-en.html
+++ b/public/fun-facts-en.html
@@ -43,6 +43,7 @@
   <script defer src="/fun-facts.js"></script>
   <link rel="stylesheet" href="/style.css">
   <script defer src="/assets/js/nav.js"></script>
+  <script defer src="/assets/js/feedback.js"></script>
 </head>
 <body>
 

--- a/public/fun-facts.html
+++ b/public/fun-facts.html
@@ -47,6 +47,7 @@
   </style>
 
   <script defer src="/fun-facts.js"></script>
+  <script defer src="/assets/js/feedback.js"></script>
 </head>
 <body>
 <main class="container section ff-wrap ff-pending" id="ff_root">

--- a/public/game-history.html
+++ b/public/game-history.html
@@ -37,6 +37,7 @@
   <script defer src="/game-history.js"></script>
   <link rel="stylesheet" href="/style.css">
   <script defer src="/assets/js/nav.js"></script>
+  <script defer src="/assets/js/feedback.js"></script>
 </head>
 <body>
 

--- a/public/index-de.html
+++ b/public/index-de.html
@@ -164,6 +164,7 @@
   </style>
   <link rel="stylesheet" href="/style.css">
   <script defer src="/assets/js/nav.js"></script>
+  <script defer src="/assets/js/feedback.js"></script>
 </head>
 <body class="panel-collapsed">
   <header aria-label="Kopfbereich">

--- a/public/index-en.html
+++ b/public/index-en.html
@@ -171,6 +171,7 @@
   </style>
   <link rel="stylesheet" href="/style.css">
   <script defer src="/assets/js/nav.js"></script>
+  <script defer src="/assets/js/feedback.js"></script>
 </head>
 <body class="panel-collapsed">
   <header aria-label="Header">

--- a/public/index.html
+++ b/public/index.html
@@ -186,6 +186,7 @@
   </style>
   <link rel="stylesheet" href="/style.css">
   <script defer src="/assets/js/nav.js"></script>
+  <script defer src="/assets/js/feedback.js"></script>
 </head>
 <body class="panel-collapsed">
   <header aria-label="En-tête">

--- a/public/passions-de.html
+++ b/public/passions-de.html
@@ -55,6 +55,7 @@
   </style>
   <link rel="stylesheet" href="/style.css">
   <script defer src="/assets/js/nav.js"></script>
+  <script defer src="/assets/js/feedback.js"></script>
 </head>
 <body>
 <header>

--- a/public/passions-en.html
+++ b/public/passions-en.html
@@ -55,6 +55,7 @@
   </style>
   <link rel="stylesheet" href="/style.css">
   <script defer src="/assets/js/nav.js"></script>
+  <script defer src="/assets/js/feedback.js"></script>
 </head>
 <body>
 <header>

--- a/public/passions.html
+++ b/public/passions.html
@@ -74,6 +74,7 @@
   </style>
   <link rel="stylesheet" href="/style.css">
   <script defer src="/assets/js/nav.js"></script>
+  <script defer src="/assets/js/feedback.js"></script>
 </head>
 <body>
 <header>

--- a/public/portfolio-de.html
+++ b/public/portfolio-de.html
@@ -35,6 +35,7 @@
   </style>
   <link rel="stylesheet" href="/style.css">
   <script defer src="/assets/js/nav.js"></script>
+  <script defer src="/assets/js/feedback.js"></script>
 </head>
 <body>
   <!-- Lokaler Header (wird von nav.js versteckt, nützlich bei no-JS) -->

--- a/public/portfolio-en.html
+++ b/public/portfolio-en.html
@@ -35,6 +35,7 @@
   </style>
   <link rel="stylesheet" href="/style.css">
   <script defer src="/assets/js/nav.js"></script>
+  <script defer src="/assets/js/feedback.js"></script>
 </head>
 <body>
   <!-- Local header (masqué par nav.js, utile en no-JS) -->

--- a/public/portfolio.html
+++ b/public/portfolio.html
@@ -35,6 +35,7 @@
   </style>
   <link rel="stylesheet" href="/style.css">
   <script defer src="/assets/js/nav.js"></script>
+  <script defer src="/assets/js/feedback.js"></script>
 </head>
 <body>
   <header class="site-header">


### PR DESCRIPTION
## Summary
- inject the feedback.js script before the closing head tag on every HTML file under public, skipping files that already referenced it

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d2630d16088329a2d30d0e0234f3c9