### PR TITLE
Move fun facts scripts before body close

### DIFF
--- a/public/fun-facts-de.html
+++ b/public/fun-facts-de.html
@@ -40,10 +40,8 @@
     @media (max-width:640px){.ff-toolbar{grid-template-columns:1fr;}}
   </style>
   <script defer src="/site.js"></script>
-  <script defer src="/fun-facts.js"></script>
   <link rel="stylesheet" href="/style.css">
   <script defer src="/assets/js/nav.js"></script>
-  <script defer src="/assets/js/feedback.js"></script>
 </head>
 <body>
 
@@ -171,5 +169,7 @@
   <p class="container">Für diese interaktive Seite ist JavaScript erforderlich.</p>
 </noscript>
 
+<script defer src="/fun-facts.js"></script>
+<script defer src="/assets/js/feedback.js"></script>
 </body>
 </html>

--- a/public/fun-facts-en.html
+++ b/public/fun-facts-en.html
@@ -40,10 +40,8 @@
     @media (max-width:640px){.ff-toolbar{grid-template-columns:1fr;}}
   </style>
   <script defer src="/site.js"></script>
-  <script defer src="/fun-facts.js"></script>
   <link rel="stylesheet" href="/style.css">
   <script defer src="/assets/js/nav.js"></script>
-  <script defer src="/assets/js/feedback.js"></script>
 </head>
 <body>
 
@@ -171,5 +169,7 @@
   <p class="container">This interactive page requires JavaScript.</p>
 </noscript>
 
+<script defer src="/fun-facts.js"></script>
+<script defer src="/assets/js/feedback.js"></script>
 </body>
 </html>

--- a/public/fun-facts.html
+++ b/public/fun-facts.html
@@ -46,8 +46,6 @@
     .ff-bubble span{font-weight:700;color:#0a1930;text-align:center;padding:0 10px}
   </style>
 
-  <script defer src="/fun-facts.js"></script>
-  <script defer src="/assets/js/feedback.js"></script>
 </head>
 <body>
 <main class="container section ff-wrap ff-pending" id="ff_root">
@@ -94,5 +92,7 @@
     <ul id="ff_fallback_list"></ul>
   </section>
 </main>
+<script defer src="/fun-facts.js"></script>
+<script defer src="/assets/js/feedback.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- relocate fun facts and feedback scripts in each fun facts page to load just before the closing body tag

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d27a1d9d748329ba5edd670aaa0138